### PR TITLE
build: Fixup for suitable usage as a meson subproject

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,11 +1,12 @@
-ecsrcs = ['ec_util.c']
-ecutil = library('ec_util', ecsrcs, dependencies: libusb, install: true, \
-    version: meson.project_version())
-
 executable(
   'htool',
-  sources: ['htool.c', 'htool_cmd.c', 'htool_console.c', 'htool_progress.c', 'htool_spi.c', 'htool_usb.c', 'ec_util.c'],
+  'htool.c',
+  'htool_cmd.c',
+  'htool_console.c',
+  'htool_progress.c',
+  'htool_spi.c',
+  'htool_usb.c',
+  'ec_util.c',
   implicit_include_directories: false,
-  dependencies: [libusb],
-  link_with: [libhoth_usb],
+  dependencies: hoth_usb_dep,
   install: true)

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,49 @@
-project('libhoth', 'c', 'cpp', license: 'Apache-2.0', version: '0.0.0')
+project(
+  'libhoth',
+  'c',
+  license: 'Apache-2.0',
+  version: '0.0.0',
+  default_options: [
+    'examples=' + (meson.is_subproject() ? 'false' : 'true'),
+  ])
 
-libhoth_usb_srcs = ['libhoth_usb.c', 'libhoth_usb_fifo.c', 'libhoth_usb_mailbox.c']
-libusb = dependency('libusb-1.0')
-libhoth_usb = library('hoth_usb', libhoth_usb_srcs, dependencies: libusb, install: true, \
-    version: meson.project_version())
+hoth_usb_deps = [
+  dependency('libusb-1.0'),
+]
+
+hoth_usb_pre = declare_dependency(
+  include_directories: include_directories('.'),
+  dependencies: hoth_usb_deps)
+
+hoth_usb_lib = library(
+  'hoth_usb',
+  'libhoth_usb.c',
+  'libhoth_usb_fifo.c',
+  'libhoth_usb_mailbox.c',
+  dependencies: hoth_usb_pre,
+  install: true,
+  version: meson.project_version())
+
+hoth_usb_dep = declare_dependency(
+  link_with: hoth_usb_lib,
+  dependencies: hoth_usb_pre)
+
 install_headers('libhoth_usb.h')
 
-pkg = import('pkgconfig')
-pkg.generate(libhoth_usb, name: 'libhoth_usb', description: 'Hoth USB interface library')
+hoth_usb_reqs = []
+foreach dep : hoth_usb_deps
+  if dep.type_name() == 'pkgconfig'
+    hoth_usb_reqs += dep
+  endif
+endforeach
 
-subdir('examples')
+pkg = import('pkgconfig')
+pkg.generate(
+  hoth_usb_lib,
+  name: 'libhoth_usb',
+  description: 'Hoth USB interface library',
+  requires: hoth_usb_reqs)
+
+if get_option('examples')
+  subdir('examples')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('examples', type: 'boolean', value: true, description: 'Build examples')


### PR DESCRIPTION
This cleans up the build structure so that we can use the `hoth_usb_dep` in meson subprojects to leverage libhoth as a dependency. This also disables building htool by default when being used a subproject library.