### PR TITLE
Extern c wrap

### DIFF
--- a/libhoth.h
+++ b/libhoth.h
@@ -17,6 +17,10 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LIBHOTH_MAILBOX_SIZE 1024
 
 typedef enum {
@@ -62,5 +66,9 @@ int libhoth_receive_response(struct libhoth_device* dev, void* response,
                                  int timeout_ms);
 
 int libhoth_device_close(struct libhoth_device* dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // _LIBHOTH_LIBHOTH_H_

--- a/libhoth_spi.h
+++ b/libhoth_spi.h
@@ -17,6 +17,10 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct libhoth_device;
 
 struct libhoth_spi_device_init_options {
@@ -34,5 +38,9 @@ struct libhoth_spi_device_init_options {
 // this function call. It can be destroyed once libhoth_spi_open returns.
 int libhoth_spi_open(const struct libhoth_spi_device_init_options* options,
                      struct libhoth_device** out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // _LIBHOTH_LIBHOTH_SPI_H_

--- a/libhoth_usb.h
+++ b/libhoth_usb.h
@@ -18,6 +18,10 @@
 #include <libusb.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct libhoth_device;
 
 struct libhoth_usb_device_init_options {
@@ -33,5 +37,9 @@ struct libhoth_usb_device_init_options {
 // this function call. It can be destroyed once libhoth_usb_open returns.
 int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
                      struct libhoth_device** out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // _LIBHOTH_LIBHOTH_USB_H_

--- a/libhoth_usb_device.h
+++ b/libhoth_usb_device.h
@@ -19,8 +19,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "libhoth_usb.h"
-
 #define LIBHOTH_USB_VENDOR_ID 0x18d1
 #define LIBHOTH_USB_INTERFACE_CLASS LIBUSB_CLASS_VENDOR_SPEC
 #define LIBHOTH_USB_MAILBOX_INTERFACE_SUBCLASS 0x71


### PR DESCRIPTION
Wrap headers in ifdef cpp extern C to be used inside c++ code.
Remove an unused include that is also a circ. dependency.