### PR TITLE
Rename ec_ commands; permit old command names as an alias.

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -42,7 +42,7 @@ static int command_usb_list(const struct htool_invocation* inv) {
   return htool_usb_print_devices();
 }
 
-static int command_ec_reboot(const struct htool_invocation* inv) {
+static int command_reboot(const struct htool_invocation* inv) {
   struct libhoth_device* dev = htool_libhoth_device();
   if (!dev) {
     return -1;
@@ -54,7 +54,7 @@ static int command_ec_reboot(const struct htool_invocation* inv) {
                             0, NULL);
 }
 
-static int command_ec_get_version(const struct htool_invocation* inv) {
+static int command_get_version(const struct htool_invocation* inv) {
   struct libhoth_device* dev = htool_libhoth_device();
   if (!dev) {
     return -1;
@@ -440,16 +440,18 @@ static const struct htool_cmd CMDS[] = {
         .func = command_usb_list,
     },
     {
-        .verbs = (const char*[]){"ec_reboot", NULL},
+        .verbs = (const char*[]){"reboot", NULL},
+        .alias = (const char*[]){"ec_reboot", NULL},
         .desc = "Reboot the RoT.",
         .params = (const struct htool_param[]){{}},
-        .func = command_ec_reboot,
+        .func = command_reboot,
     },
     {
-        .verbs = (const char*[]){"ec_get_version", NULL},
+        .verbs = (const char*[]){"show", "firmware_version", NULL},
+        .alias = (const char*[]){"ec_get_version", NULL},
         .desc = "Get the version of the RoT firmware.",
         .params = (const struct htool_param[]){{}},
-        .func = command_ec_get_version,
+        .func = command_get_version,
     },
     {
         .verbs = (const char*[]){"show", "chipinfo", NULL},

--- a/examples/htool_cmd.h
+++ b/examples/htool_cmd.h
@@ -43,6 +43,7 @@ struct htool_invocation;
 
 struct htool_cmd {
   const char* const* verbs;
+  const char* const* alias;
   const char* desc;
   const struct htool_param* params;
   int (*func)(const struct htool_invocation*);


### PR DESCRIPTION
The "ec_" prefix doesn't mean anything coherent any more, and should be removed from pretty much everywhere.

User-visible command changes:
* "htool ec_reboot" --> "htool reboot"
* "htool ec_get_version" --> "htool show firmware_version" (This command fits better into the "show" category anyhow.)

This only supports one alias per command for now, because I don't expect we'll need multiple aliases (yet, at least).