### PR TITLE
Expose header files expose USB APIs

### DIFF
--- a/libhoth_usb.c
+++ b/libhoth_usb.c
@@ -27,8 +27,6 @@ int libhoth_usb_receive_response(struct libhoth_device* dev, void* response,
                                  size_t max_response_size, size_t* actual_size,
                                  int timeout_ms);
 
-int libhoth_usb_close(struct libhoth_device* dev);
-
 static struct libhoth_usb_interface_info libhoth_usb_find_interface(
     const struct libusb_config_descriptor* configuration) {
   struct libhoth_usb_interface_info info = {

--- a/libhoth_usb.h
+++ b/libhoth_usb.h
@@ -37,6 +37,12 @@ struct libhoth_usb_device_init_options {
 int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
                      struct libhoth_device** out);
 
+int libhoth_usb_close(struct libhoth_device* dev);
+
+int libhoth_usb_receive_response(struct libhoth_device* dev, void* response,
+                                 size_t max_response_size, size_t* actual_size,
+                                 int timeout_ms);
+
 #ifdef __cplusplus
 }
 #endif

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ libusb = dependency('libusb-1.0')
 libhoth = library('hoth', libhoth_srcs, dependencies: libusb, install: true, \
     version: meson.project_version())
 install_headers('libhoth.h')
+install_headers('libhoth_usb.h')
+install_headers('libhoth_usb_device.h')
 
 pkg = import('pkgconfig')
 pkg.generate(libhoth, name: 'libhoth', description: 'Hoth interface library')


### PR DESCRIPTION
Allow hoth_usb APIs to be accessiable and used by internal hoth libraries.