### PR TITLE
Stamp Git commit for `htool --version`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --stamp --workspace_status_command '$(pwd)/print_git_commit.sh'

--- a/BUILD
+++ b/BUILD
@@ -20,3 +20,17 @@ cc_library(
     ],
     deps = ["@libusb//:libusb"],
 )
+
+cc_library(
+    name = "git_version",
+    hdrs = [":gen_version_header"],
+)
+
+genrule(
+    name = "gen_version_header",
+    outs = ["git_version.h"],
+    cmd = "$(location :print_version_header.sh) > \"$@\"",
+    tools = [":print_version_header.sh"],
+    stamp = 1,
+)
+

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -58,6 +58,7 @@ cc_binary(
         ":authorization_record",
         ":ec_util",
         ":host_commands",
+        "//:git_version",
         "//:libhoth",
         "@libusb//:libusb",
     ],

--- a/examples/git_version.h.in
+++ b/examples/git_version.h.in
@@ -1,0 +1,6 @@
+#ifndef LIBHOTH_GIT_VERSION_H
+#define LIBHOTH_GIT_VERSION_H
+
+#define STABLE_GIT_COMMIT "@GIT_COMMIT@" 
+
+#endif

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -787,6 +787,8 @@ static const struct htool_param GLOBAL_FLAGS[] = {
     {HTOOL_FLAG_VALUE, .name = "mailbox_location", .default_value = "0",
      .desc = "The location of the mailbox on the RoT, for 'spidev' "
              "or 'mtd' transports; for example '0x900000'."},
+    {HTOOL_FLAG_BOOL, .name = "version", .default_value = "false",
+     .desc = "Print htool version."},
     {}};
 
 int main(int argc, const char* const* argv) {

--- a/examples/htool_cmd.c
+++ b/examples/htool_cmd.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "git_version.h"
+
 static int matches_verbs(const char* const* verbs, int argc,
                          const char* const* argv) {
   for (int i = 0; i < argc; i++) {
@@ -430,6 +432,19 @@ int htool_main(const struct htool_param* global_flags,
   if (num_global_flag_args < 0) {
     return -1;
   }
+
+  bool print_version;
+  int rv =
+      htool_get_param_bool(htool_global_flags(), "version", &print_version);
+  if (rv) {
+    return rv;
+  }
+
+  if (print_version) {
+    printf("%s\n", STABLE_GIT_COMMIT);
+    return 0;
+  }
+
   argc -= num_global_flag_args;
   argv += num_global_flag_args;
 
@@ -446,7 +461,7 @@ int htool_main(const struct htool_param* global_flags,
   argv += num_verb_words;
 
   struct htool_invocation inv;
-  int rv = fill_cmd_invocation(&inv, cmd, argc, argv);
+  rv = fill_cmd_invocation(&inv, cmd, argc, argv);
   if (rv != 0) {
     return rv;
   }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -2,6 +2,13 @@ ecsrcs = ['ec_util.c']
 ecutil = library('ec_util', ecsrcs, dependencies: libusb, install: true, \
     version: meson.project_version())
 
+git_version_h = vcs_tag(
+  command: ['git', 'describe', '--always', '--dirty', '--abbrev=40'],
+  input: 'git_version.h.in',
+  output: 'git_version.h',
+  replace_string: '@GIT_COMMIT@',
+)
+
 executable(
   'htool',
   sources: [
@@ -18,8 +25,8 @@ executable(
     'htool_spi.c',
     'htool_spi_proxy.c',
     'htool_statistics.c',
-    'htool_usb.c'],
-  implicit_include_directories: false,
+    'htool_usb.c',
+    git_version_h],
   dependencies: [libusb],
   link_with: [libhoth],
   install: true)

--- a/print_git_commit.sh
+++ b/print_git_commit.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# https://bazel.build/docs/user-manual#workspace-status
+
+if ! commit=$(git describe --always --dirty --abbrev=40); then
+  >&2 echo "failed to get SHA-1 of HEAD"
+  exit 1
+fi
+
+echo "STABLE_GIT_COMMIT $commit"
+

--- a/print_version_header.sh
+++ b/print_version_header.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+git_commit=$(sed -nE 's/^STABLE_GIT_COMMIT ([a-z0-9\-]+)$/\1/p' bazel-out/stable-status.txt)
+
+if [ -z "$git_commit" ]; then
+  >&2 echo "failed to parse Git commit"
+  exit 1
+fi
+
+header="
+#ifndef LIBHOTH_EXAMPLES_HTOOL_VERSION_H_
+#define LIBHOTH_EXAMPLES_HTOOL_VERSION_H_
+
+#define STABLE_GIT_COMMIT \"$git_commit\" 
+
+#endif
+"
+
+echo "$header"


### PR DESCRIPTION
The version is:
1. The SHA-1 of `HEAD` when building; and,
2. Whether the working directory had uncommitted changes (`"dirty"`).

### Bazel
```
$ bazel build ...
INFO: Analyzed 7 targets (0 packages loaded, 0 targets configured).
INFO: Found 7 targets...
INFO: Elapsed time: 0.132s, Critical Path: 0.07s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

$ bazel-bin/examples/htool --version
9de9cc42c7d8a6ca0f32d9c7ccdfa0b4e9ebf133-dirty
```
### Meson
```
$ (cd build && ninja)
[3/3] Linking target examples/htool

$ build/examples/htool --version
9de9cc42c7d8a6ca0f32d9c7ccdfa0b4e9ebf133-dirty
```