### PR TITLE
Update print_version_header.sh

### DIFF
--- a/print_version_header.sh
+++ b/print_version_header.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git_commit=$(sed -nE 's/^STABLE_GIT_COMMIT ([a-z0-9\-]+)$/\1/p' bazel-out/stable-status.txt)
+git_commit=$(sed -nr 's/^STABLE_GIT_COMMIT ([a-z0-9\-]+)$/\1/p' bazel-out/stable-status.txt)
 
 if [ -z "$git_commit" ]; then
   >&2 echo "failed to parse Git commit"


### PR DESCRIPTION
Change the sed flag from -E to -r. 

-E is on some versions of sed for compatibility with BSD; -r is the GNU variant. See https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed for details.