### PR TITLE
Claim + Release USB connection when running `htool console`

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -442,16 +442,19 @@ static int command_console(const struct htool_invocation* inv) {
 
   if (htool_get_param_bool(inv, "snapshot", &opts.snapshot)) {
     return -1;
-  };
+  }
 
   if (!opts.snapshot) {
     if (htool_get_param_u32_or_fourcc(inv, "channel", &opts.channel_id) ||
         htool_get_param_bool(inv, "force_drive_tx", &opts.force_drive_tx) ||
         htool_get_param_bool(inv, "history", &opts.history) ||
         htool_get_param_bool(inv, "onlcr", &opts.onlcr) ||
-        htool_get_param_u32(inv, "baud_rate", &opts.baud_rate)) {
+        htool_get_param_u32(inv, "baud_rate", &opts.baud_rate) ||
+        htool_get_param_u32(inv, "claim_timeout_secs",
+                            &opts.claim_timeout_secs) ||
+        htool_get_param_u32(inv, "yield_ms", &opts.yield_ms)) {
       return -1;
-    };
+    }
   }
   struct libhoth_device* dev = htool_libhoth_device();
   if (!dev) {
@@ -696,6 +699,15 @@ static const struct htool_cmd CMDS[] = {
                 {HTOOL_FLAG_VALUE, 'b', "baud_rate", "0"},
                 {HTOOL_FLAG_BOOL, 's', "snapshot", "false",
                  .desc = "Print a snapshot of most recent console messages."},
+                {HTOOL_FLAG_VALUE, .name = "claim_timeout_secs",
+                 .default_value = "60",
+                 .desc = "How long we should attempt to claim the device "
+                         "before returning a fatal error."},
+                {HTOOL_FLAG_VALUE, .name = "yield_ms", .default_value = "50",
+                 .desc = "After releasing the device, how long we should wait "
+                         "before claiming it again. Decrease to reduce console "
+                         "latency. Increase to reduce contention between "
+                         "concurrent clients."},
                 {}},
         .func = command_console,
     },

--- a/examples/htool_console.c
+++ b/examples/htool_console.c
@@ -243,6 +243,53 @@ static int set_uart_config(struct libhoth_device *dev,
       /*version=*/0, &req, sizeof(req), NULL, 0, NULL);
 }
 
+// Try to claim `dev`. If `dev` is already claimed, then try to claim later by
+// waiting an exponentially backed off amount of time.
+static int claim_device(struct libhoth_device *dev, uint32_t timeout_us) {
+  enum {
+    // The maximum time to sleep per attempt.
+    // Limited by `usleep()` to <1 second.
+    MAX_SINGLE_SLEEP_US = 1000 * 1000 - 1,
+    BACKOFF_FACTOR = 2,
+    INITIAL_WAIT_US = 10 * 1000,
+  };
+
+  uint32_t wait_us = INITIAL_WAIT_US;
+  uint32_t total_waiting_us = 0;
+
+  while (true) {
+    int status = dev->claim(dev);
+
+    if (status != LIBHOTH_ERR_INTERFACE_BUSY) {
+      // We either claimed the device or encountered an unexpected error. Let
+      // the caller know.
+      return status;
+    }
+
+    if (total_waiting_us >= timeout_us) {
+      // We've exhausted our waiting budget. We couldn't claim the device
+      // within the configured timeout.
+      return LIBHOTH_ERR_INTERFACE_BUSY;
+    }
+
+    usleep(wait_us);
+
+    if (total_waiting_us <= UINT32_MAX - wait_us) {
+      total_waiting_us += wait_us;
+    } else {
+      // Saturate at integer upper bound to prevent overflow.
+      total_waiting_us = UINT32_MAX;
+    }
+
+    if (wait_us <= MAX_SINGLE_SLEEP_US / BACKOFF_FACTOR) {
+      wait_us *= BACKOFF_FACTOR;
+    } else {
+      // Saturate at the `usleep()` max sleep bound.
+      wait_us = MAX_SINGLE_SLEEP_US;
+    }
+  }
+}
+
 int htool_console_run(struct libhoth_device *dev,
                       const struct htool_console_opts *opts) {
   printf("%sStarting Interactive Console\n", kAnsiRed);
@@ -284,6 +331,7 @@ int htool_console_run(struct libhoth_device *dev,
   // buffer is much smaller than 2GB).
   if (opts->history) offset -= 0x80000000;
   bool quit = false;
+
   while (!quit) {
     status = read_console(dev, opts, &offset);
     if (status != LIBHOTH_OK) {
@@ -294,10 +342,21 @@ int htool_console_run(struct libhoth_device *dev,
     if (status != LIBHOTH_OK) {
       break;
     }
+
+    dev->release(dev);
+
+    // Give an opportunity for other clients to use the interface.
+    usleep(1000 * opts->yield_ms);
+
+    status = claim_device(dev, 1000 * 1000 * opts->claim_timeout_secs);
+    if (status != LIBHOTH_OK) {
+      break;
+    }
   }
+
   restore_terminal(STDIN_FILENO, &old_termios);
   printf("\n");
-  return 0;
+  return status;
 }
 
 int htool_console_snapshot(struct libhoth_device *dev) {

--- a/examples/htool_console.h
+++ b/examples/htool_console.h
@@ -27,6 +27,8 @@ struct htool_console_opts {
   bool onlcr;
   uint32_t baud_rate;
   bool snapshot;
+  uint32_t claim_timeout_secs;
+  uint32_t yield_ms;
 };
 
 int htool_console_run(struct libhoth_device* dev,

--- a/libhoth.h
+++ b/libhoth.h
@@ -35,6 +35,7 @@ typedef enum {
   LIBHOTH_ERR_INVALID_PARAMETER = 8,
   LIBHOTH_ERR_FAIL = 9,
   LIBHOTH_ERR_RESPONSE_BUFFER_OVERFLOW = 10,
+  LIBHOTH_ERR_INTERFACE_BUSY = 11,
 } libhoth_status;
 
 struct libhoth_device {
@@ -43,6 +44,8 @@ struct libhoth_device {
   int (*receive)(struct libhoth_device *dev, void *response,
                  size_t max_response_size, size_t *actual_size, int timeout_ms);
   int (*close)(struct libhoth_device *dev);
+  int (*claim)(struct libhoth_device *dev);
+  int (*release)(struct libhoth_device *dev);
 
   void *user_ctx;
 };

--- a/libhoth_mtd.c
+++ b/libhoth_mtd.c
@@ -98,6 +98,16 @@ static int mtd_write(int fd, unsigned int address, const void* data,
   return LIBHOTH_OK;
 }
 
+static int libhoth_mtd_claim(struct libhoth_device* dev) {
+  // no-op
+  return LIBHOTH_OK;
+}
+
+static int libhoth_mtd_release(struct libhoth_device* dev) {
+  // no-op
+  return LIBHOTH_OK;
+}
+
 static int mtd_open(const char* path, const char* name) {
   if (strlen(path) > 0) {
     return open(path, O_RDWR);
@@ -179,6 +189,8 @@ int libhoth_mtd_open(const struct libhoth_mtd_device_init_options* options,
   dev->send = libhoth_mtd_send_request;
   dev->receive = libhoth_mtd_receive_response;
   dev->close = libhoth_mtd_close;
+  dev->claim = libhoth_mtd_claim;
+  dev->release = libhoth_mtd_release;
   dev->user_ctx = mtd_dev;
 
   *out = dev;

--- a/libhoth_spi.c
+++ b/libhoth_spi.c
@@ -130,6 +130,16 @@ static int spi_nor_read(int fd, unsigned int address_mode_4b,
   return LIBHOTH_OK;
 }
 
+static int libhoth_spi_claim(struct libhoth_device* dev) {
+  // no-op
+  return LIBHOTH_OK;
+}
+
+static int libhoth_spi_release(struct libhoth_device* dev) {
+  // no-op
+  return LIBHOTH_OK;
+}
+
 int libhoth_spi_open(const struct libhoth_spi_device_init_options* options,
                      struct libhoth_device** out) {
   if (out == NULL || options == NULL || options->path == NULL) {
@@ -190,6 +200,8 @@ int libhoth_spi_open(const struct libhoth_spi_device_init_options* options,
   dev->send = libhoth_spi_send_request;
   dev->receive = libhoth_spi_receive_response;
   dev->close = libhoth_spi_close;
+  dev->claim = libhoth_spi_claim;
+  dev->release = libhoth_spi_release;
   dev->user_ctx = spi_dev;
 
   *out = dev;

--- a/libhoth_usb.c
+++ b/libhoth_usb.c
@@ -60,6 +60,24 @@ static struct libhoth_usb_interface_info libhoth_usb_find_interface(
   return info;
 }
 
+static int libhoth_usb_claim(struct libhoth_device* dev) {
+  struct libhoth_usb_device* usb_dev = dev->user_ctx;
+
+  int status =
+      libusb_claim_interface(usb_dev->handle, usb_dev->info.interface_id);
+
+  if (status == LIBUSB_ERROR_BUSY) {
+    return LIBHOTH_ERR_INTERFACE_BUSY;
+  }
+
+  return status;
+}
+
+static int libhoth_usb_release(struct libhoth_device* dev) {
+  struct libhoth_usb_device* usb_dev = dev->user_ctx;
+  return libusb_release_interface(usb_dev->handle, usb_dev->info.interface_id);
+}
+
 int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
                      struct libhoth_device** out) {
   if (out == NULL || options == NULL || options->usb_device == NULL) {
@@ -136,6 +154,8 @@ int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
   dev->send = libhoth_usb_send_request;
   dev->receive = libhoth_usb_receive_response;
   dev->close = libhoth_usb_close;
+  dev->claim = libhoth_usb_claim;
+  dev->release = libhoth_usb_release;
   dev->user_ctx = usb_dev;
 
   *out = dev;


### PR DESCRIPTION
This PR adjusts `htool console` to intermittently yield its USB claim. This yielding should allow a small number of concurrent `htool` clients to run `htool console`.

`htool console` has two new optional arguments:
```
--claim_timeout_secs (default: "60")
      How long we should attempt to claim the device before returning a fatal error.
--yield_ms (default: "50")
      After releasing the device, how long we should wait before claiming it again. Decrease to reduce console latency. Increase to reduce contention between concurrent clients.
```

This PR _doesn't_ change the logic to initially claim the USB device when running `htool`.