### PR TITLE
Add support for payload update protocol for generic Titan images.

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -43,6 +43,8 @@ cc_binary(
         "htool_panic.h",
         "htool_payload.c",
         "htool_payload.h",
+        "htool_payload_update.c",
+        "htool_payload_update.h",
         "htool_progress.c",
         "htool_progress.h",
         "htool_spi.c",

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -478,6 +478,19 @@ struct ec_authz_record_get_nonce_response {
 #define EC_PRV_CMD_HOTH_PAYLOAD_UPDATE 0x0005
 #define EC_PRV_CMD_HOTH_PAYLOAD_STATUS 0x0006
 
+#define PAYLOAD_UPDATE_INITIATE 0
+#define PAYLOAD_UPDATE_CONTINUE 1
+#define PAYLOAD_UPDATE_FINALIZE 2
+#define PAYLOAD_UPDATE_AUX_DATA 3
+#define PAYLOAD_UPDATE_VERIFY 4
+#define PAYLOAD_UPDATE_ACTIVATE 5
+#define PAYLOAD_UPDATE_READ 6
+#define PAYLOAD_UPDATE_GET_STATUS 7
+#define PAYLOAD_UPDATE_ERASE 8
+#define PAYLOAD_UPDATE_VERIFY_CHUNK 9
+#define PAYLOAD_UPDATE_CONFIRM 10
+#define PAYLOAD_UPDATE_VERIFY_DESCRIPTOR 11
+
 struct payload_status_response_header {
   uint8_t version;
   uint8_t lockdown_state;
@@ -498,6 +511,13 @@ struct payload_region_state {
   uint32_t version_point;
   uint32_t version_subpoint;
   uint32_t descriptor_offset; /* can be used to pull the image hash/signature */
+} __attribute__((packed));
+
+struct payload_update_packet {
+  uint32_t offset; /* image offset */
+  uint32_t len; /* packet length excluding this header */
+  uint8_t type; /* One of PAYLOAD_UPDATE_* */
+  /* payload data immediately follows */
 } __attribute__((packed));
 
 #define EC_PRV_CMD_HOTH_PERSISTENT_PANIC_INFO 0x0014

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -515,8 +515,8 @@ struct payload_region_state {
 
 struct payload_update_packet {
   uint32_t offset; /* image offset */
-  uint32_t len; /* packet length excluding this header */
-  uint8_t type; /* One of PAYLOAD_UPDATE_* */
+  uint32_t len;    /* packet length excluding this header */
+  uint8_t type;    /* One of PAYLOAD_UPDATE_* */
   /* payload data immediately follows */
 } __attribute__((packed));
 

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -594,7 +594,7 @@ int htool_exec_hostcmd(struct libhoth_device* dev, uint16_t command,
   } resp;
   size_t resp_size;
   status = libhoth_receive_response(dev, &resp, sizeof(resp), &resp_size,
-                                    /*timeout_ms=*/5000);
+                                    /*timeout_ms=*/15000);
   if (status != LIBHOTH_OK) {
     fprintf(stderr, "libhoth_usb_receive_response() failed: %d\n", status);
     return -1;

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -768,8 +768,7 @@ static const struct htool_cmd CMDS[] = {
         .desc = "Perform payload update protocol for Titan images.",
         .params =
             (const struct htool_param[]){
-                {HTOOL_POSITIONAL, .name = "source-file"},
-                {}},
+                {HTOOL_POSITIONAL, .name = "source-file"}, {}},
         .func = htool_payload_update,
     },
     {.verbs = (const char*[]){"flash_spi_info", NULL},

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -594,7 +594,7 @@ int htool_exec_hostcmd(struct libhoth_device* dev, uint16_t command,
   } resp;
   size_t resp_size;
   status = libhoth_receive_response(dev, &resp, sizeof(resp), &resp_size,
-                                    /*timeout_ms=*/15000);
+                                    /*timeout_ms=*/180000);
   if (status != LIBHOTH_OK) {
     fprintf(stderr, "libhoth_usb_receive_response() failed: %d\n", status);
     return -1;

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -36,6 +36,7 @@
 #include "htool_console.h"
 #include "htool_panic.h"
 #include "htool_payload.h"
+#include "htool_payload_update.h"
 #include "htool_progress.h"
 #include "htool_spi_proxy.h"
 #include "htool_statistics.h"
@@ -761,6 +762,15 @@ static const struct htool_cmd CMDS[] = {
         .desc = "Show payload status",
         .params = (const struct htool_param[]){{}},
         .func = htool_payload_status,
+    },
+    {
+        .verbs = (const char*[]){"payload", "update", NULL},
+        .desc = "Perform payload update protocol for Titan images.",
+        .params =
+            (const struct htool_param[]){
+                {HTOOL_POSITIONAL, .name = "source-file"},
+                {}},
+        .func = htool_payload_update,
     },
     {.verbs = (const char*[]){"flash_spi_info", NULL},
      .desc = "Get SPI NOR flash info.",

--- a/examples/htool_payload_update.c
+++ b/examples/htool_payload_update.c
@@ -31,7 +31,8 @@
 const int64_t TITAN_IMAGE_DESCRIPTOR_MAGIC = 0x5F435344474D495F;
 const int64_t TITAN_IMAGE_DESCRIPTOR_ALIGNMENT = 1 << 16;
 
-bool find_image_descriptor(uint8_t *image, size_t len, size_t offset_alignment, int64_t magic) {
+bool find_image_descriptor(uint8_t *image, size_t len, size_t offset_alignment,
+                           int64_t magic) {
   for (size_t offset = 0; offset < len; offset += offset_alignment) {
     int64_t magic_candidate;
     memcpy(&magic_candidate, image + offset, sizeof(int64_t));
@@ -43,7 +44,7 @@ bool find_image_descriptor(uint8_t *image, size_t len, size_t offset_alignment, 
 }
 
 int send_payload_update_request_with_command(struct libhoth_device *dev,
-                                                    uint8_t command) {
+                                             uint8_t command) {
   struct payload_update_packet request;
   request.type = command;
   request.offset = 0;
@@ -59,8 +60,7 @@ int send_payload_update_request_with_command(struct libhoth_device *dev,
   return 0;
 }
 
-int send_image(struct libhoth_device *dev, const uint8_t *image,
-                      size_t size) {
+int send_image(struct libhoth_device *dev, const uint8_t *image, size_t size) {
   const size_t max_chunk_size = MAILBOX_SIZE - sizeof(struct ec_host_request) -
                                 sizeof(struct payload_update_packet);
 
@@ -107,7 +107,7 @@ int send_image(struct libhoth_device *dev, const uint8_t *image,
 int htool_payload_update(const struct htool_invocation *inv) {
   struct libhoth_device *dev = htool_libhoth_device();
   if (!dev) {
-   return -1;
+    return -1;
   }
 
   const char *image_file;
@@ -132,7 +132,9 @@ int htool_payload_update(const struct htool_invocation *inv) {
 
   uint8_t *image = mmap(NULL, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
 
-  if (!find_image_descriptor(image, statbuf.st_size, TITAN_IMAGE_DESCRIPTOR_ALIGNMENT, TITAN_IMAGE_DESCRIPTOR_MAGIC)) {
+  if (!find_image_descriptor(image, statbuf.st_size,
+                             TITAN_IMAGE_DESCRIPTOR_ALIGNMENT,
+                             TITAN_IMAGE_DESCRIPTOR_MAGIC)) {
     fprintf(stderr, "Not a valid Titan image.");
     goto cleanup;
   }
@@ -166,7 +168,7 @@ int htool_payload_update(const struct htool_invocation *inv) {
 
   return 0;
 
-  cleanup:
+cleanup:
   ret = munmap(image, statbuf.st_size);
   if (ret != 0) {
     fprintf(stderr, "munmap error: %d", ret);

--- a/examples/htool_payload_update.c
+++ b/examples/htool_payload_update.c
@@ -1,0 +1,175 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "htool_payload_update.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "host_commands.h"
+#include "htool.h"
+#include "htool_cmd.h"
+
+const int64_t TITAN_IMAGE_DESCRIPTOR_MAGIC = 0x5F435344474D495F;
+const int64_t TITAN_IMAGE_DESCRIPTOR_ALIGNMENT = 1 << 16;
+
+bool find_image_descriptor(uint8_t *image, size_t len, size_t offset_alignment, int64_t magic) {
+  for (size_t offset = 0; offset < len; offset += offset_alignment) {
+    int64_t magic_candidate;
+    memcpy(&magic_candidate, image + offset, sizeof(int64_t));
+    if (magic_candidate == magic) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int send_payload_update_request_with_command(struct libhoth_device *dev,
+                                                    uint8_t command) {
+  struct payload_update_packet request;
+  request.type = command;
+  request.offset = 0;
+  request.len = 0;
+
+  int ret = htool_exec_hostcmd(
+      dev, EC_CMD_BOARD_SPECIFIC_BASE | EC_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
+      &request, sizeof(request), NULL, 0, NULL);
+  if (ret != 0) {
+    fprintf(stderr, "Error code from hoth: %d\n", ret);
+    return -1;
+  }
+  return 0;
+}
+
+int send_image(struct libhoth_device *dev, const uint8_t *image,
+                      size_t size) {
+  const size_t max_chunk_size = MAILBOX_SIZE - sizeof(struct ec_host_request) -
+                                sizeof(struct payload_update_packet);
+
+  for (size_t offset = 0; offset < size; ++offset) {
+    if (image[offset] == 0xFF) {
+      continue;
+    }
+    struct payload_update_packet request;
+
+    size_t chunk_size = max_chunk_size;
+    if (size - offset < chunk_size) {
+      chunk_size = size - offset;
+    }
+
+    while (chunk_size > 0 && image[offset + chunk_size - 1] == 0xFF) {
+      --chunk_size;
+    }
+
+    if (chunk_size == 0) {
+      continue;
+    }
+
+    request.offset = offset;
+    request.len = chunk_size;
+    request.type = PAYLOAD_UPDATE_CONTINUE;
+
+    uint8_t buffer[sizeof(struct payload_update_packet) + MAILBOX_SIZE];
+    memcpy(buffer, &request, sizeof(request));
+    memcpy(buffer + sizeof(request), image + offset, chunk_size);
+
+    int ret = htool_exec_hostcmd(
+        dev, EC_CMD_BOARD_SPECIFIC_BASE | EC_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
+        buffer, sizeof(request) + chunk_size, NULL, 0, NULL);
+    if (ret != 0) {
+      fprintf(stderr, "Error code from hoth: %d", ret);
+      return -1;
+    }
+
+    offset += chunk_size - 1;
+  }
+  return 0;
+}
+
+int htool_payload_update(const struct htool_invocation *inv) {
+  struct libhoth_device *dev = htool_libhoth_device();
+  if (!dev) {
+   return -1;
+  }
+
+  const char *image_file;
+  if (htool_get_param_string(inv, "source-file", &image_file)) {
+    return -1;
+  }
+
+  int fd = open(image_file, O_RDONLY, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening file %s: %s\n", image_file, strerror(errno));
+    return -1;
+  }
+  struct stat statbuf;
+  if (fstat(fd, &statbuf)) {
+    fprintf(stderr, "fstat error: %s\n", strerror(errno));
+    return -1;
+  }
+  if (statbuf.st_size > SIZE_MAX) {
+    fprintf(stderr, "file to large\n");
+    return -1;
+  }
+
+  uint8_t *image = mmap(NULL, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+
+  if (!find_image_descriptor(image, statbuf.st_size, TITAN_IMAGE_DESCRIPTOR_ALIGNMENT, TITAN_IMAGE_DESCRIPTOR_MAGIC)) {
+    fprintf(stderr, "Not a valid Titan image.");
+    goto cleanup;
+  }
+
+  // Hoth payload update protocol.
+
+  // Send initiate.
+  fprintf(stderr, "Initiating payload update protocol with hoth.\n");
+  int ret =
+      send_payload_update_request_with_command(dev, PAYLOAD_UPDATE_INITIATE);
+  if (ret != 0) {
+    fprintf(stderr, "Error when initiating payload update.");
+    goto cleanup;
+  }
+
+  // Send continue.
+  fprintf(stderr, "Flashing the image to hoth.\n");
+  ret = send_image(dev, image, statbuf.st_size);
+  if (ret != 0) {
+    fprintf(stderr, "Error when flashing.");
+    goto cleanup;
+  }
+
+  // Send finalize.
+  fprintf(stderr, "Finalizing payload update.\n");
+  ret = send_payload_update_request_with_command(dev, PAYLOAD_UPDATE_FINALIZE);
+  if (ret != 0) {
+    fprintf(stderr, "Error when finalizing.");
+    goto cleanup;
+  }
+
+  return 0;
+
+  cleanup:
+  ret = munmap(image, statbuf.st_size);
+  if (ret != 0) {
+    fprintf(stderr, "munmap error: %d", ret);
+  }
+  return -1;
+}

--- a/examples/htool_payload_update.h
+++ b/examples/htool_payload_update.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_H_
-#define LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_H_
+#ifndef LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_UPDATE_H_
+#define LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_UPDATE_H_
 
 #include "host_commands.h"
 #include "htool.h"

--- a/examples/htool_payload_update.h
+++ b/examples/htool_payload_update.h
@@ -1,0 +1,24 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_H_
+#define LIBHOTH_EXAMPLES_HTOOL_PAYLOAD_H_
+
+#include "host_commands.h"
+#include "htool.h"
+
+struct htool_invocation;
+int htool_payload_update(const struct htool_invocation* inv);
+
+#endif

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -21,6 +21,7 @@ executable(
     'htool_mtd.c',
     'htool_panic.c',
     'htool_payload.c',
+    'htool_payload_update.c',
     'htool_progress.c',
     'htool_spi.c',
     'htool_spi_proxy.c',


### PR DESCRIPTION
1. Add "payload update" as an available command to htool.
2. When "payload update" is invoked, htool will parse the provided image and look for a Titan descriptor, validating the image.
3. If the image is validated, htool will follow the generic "payload update" protocol with the hoth device.
3a. First, htool will send an INITIATE command to the hoth device.
3b. Then, htool will partition the image into chunks of allowed size and send the chunks.
3c. Lastly, htool will finish the protocol by sending a FINALIZE command.

Out of scope:
1. Supporting specific Titan image / hoth device families. Those reside at an offset 52 within the descriptor. Different commands may need to be sent for those devices in the payload update protocol.