### PR TITLE
Add ability to process raw host commands

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -47,6 +47,8 @@ cc_binary(
         "htool_payload_update.h",
         "htool_progress.c",
         "htool_progress.h",
+        "htool_raw_host_command.c",
+        "htool_raw_host_command.h",
         "htool_spi.c",
         "htool_spi_proxy.c",
         "htool_spi_proxy.h",

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -38,6 +38,7 @@
 #include "htool_payload.h"
 #include "htool_payload_update.h"
 #include "htool_progress.h"
+#include "htool_raw_host_command.h"
 #include "htool_spi_proxy.h"
 #include "htool_statistics.h"
 #include "htool_usb.h"
@@ -840,6 +841,12 @@ static const struct htool_cmd CMDS[] = {
                 "trigger.",
         .params = (const struct htool_param[]){{}},
         .func = command_arm_coordinated_reset,
+    },
+    {
+        .verbs = (const char*[]){"raw_host_command", NULL},
+        .desc = "Stream raw host commands via stdin/stdout",
+        .params = (const struct htool_param[]){{}},
+        .func = command_raw_host_command,
     },
     {},
 };

--- a/examples/htool_raw_host_command.c
+++ b/examples/htool_raw_host_command.c
@@ -1,0 +1,156 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../libhoth.h"
+#include "ec_util.h"
+#include "host_commands.h"
+#include "htool.h"
+#include "htool_cmd.h"
+
+// Return -1 on IO error.
+// Otherwise, return number of bytes of read.
+static int fd_read(int fd, void* buf, size_t count) {
+  ssize_t rc = read(fd, buf, count);
+  if (rc == -1) {
+    perror("read() failed");
+  }
+  return rc;
+}
+
+// Return -1 on IO error.
+// Return 1 on EOF.
+// Return 0 on success, i.e., reading `count` bytes into `buf`.
+static int fd_read_exact(int fd, void* buf, size_t count) {
+  uint8_t* buf_u8 = (uint8_t*)buf;
+  while (count > 0) {
+    ssize_t bytes_read = fd_read(fd, buf_u8, count);
+    if (bytes_read == -1) {
+      // IO error
+      return -1;
+    }
+    if (bytes_read == 0) {
+      // EOF
+      return 1;
+    }
+    count -= bytes_read;
+    buf_u8 += bytes_read;
+  }
+  return 0;
+}
+
+// Return -1 on IO error.
+// Otherwise, return number of written bytes.
+static int fd_write(int fd, const void* buf, size_t count) {
+  ssize_t rc = write(fd, buf, count);
+  if (rc == -1) {
+    perror("write() failed");
+  }
+  return rc;
+}
+
+static int fd_write_exact(int fd, const void* buf, size_t count) {
+  while (count > 0) {
+    ssize_t bytes_written = fd_write(fd, buf, count);
+    if (bytes_written <= 0) {
+      return -1;
+    }
+    buf = (const uint8_t*)(buf) + bytes_written;
+    count -= bytes_written;
+  }
+  return 0;
+}
+
+int command_raw_host_command(const struct htool_invocation* inv) {
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  while (true) {
+    struct ec_host_request req;
+    int rv = fd_read_exact(STDIN_FILENO, &req, sizeof(req));
+    if (rv == -1) {
+      // IO error.
+      return rv;
+    } else if (rv == 1) {
+      // EOF. We can bail successfully because there are no more request
+      // headers on stdin.
+      return 0;
+    }
+
+    uint8_t req_payload[LIBHOTH_MAILBOX_SIZE - sizeof(struct ec_host_request)] =
+        {0};
+
+    if (req.data_len > sizeof(req_payload)) {
+      fprintf(stderr, "request payload size too large: %d > %ld\n",
+              req.data_len, sizeof(req_payload));
+      return -1;
+    }
+
+    rv = fd_read_exact(STDIN_FILENO, req_payload, req.data_len);
+    if (rv) {
+      // Either IO error or EOF.
+      // We treat EOF as an error in this case because the request is
+      // incomplete: we read the header but failed to read its payload.
+      return rv;
+    }
+
+    uint8_t checksum = calculate_ec_command_checksum(&req, sizeof(req),
+                                                     req_payload, req.data_len);
+    if (checksum != 0) {
+      fprintf(stderr, "bad request checksum; expected 0, got %d\n", checksum);
+      return -1;
+    }
+
+    struct ec_host_response resp = {
+        .struct_version = 3,
+    };
+
+    enum { RESP_BUF_LEN = 2048 };
+    uint8_t resp_payload[RESP_BUF_LEN] = {0};
+
+    size_t actual_resp_size = 0;
+    rv = htool_exec_hostcmd(dev, req.command, req.command_version, req_payload,
+                            req.data_len, resp_payload, RESP_BUF_LEN,
+                            &actual_resp_size);
+    if (rv && rv < HTOOL_ERROR_HOST_COMMAND_START) {
+      return rv;
+    }
+    if (rv > HTOOL_ERROR_HOST_COMMAND_START) {
+      resp.result = rv - HTOOL_ERROR_HOST_COMMAND_START;
+    }
+
+    resp.data_len = actual_resp_size;
+    resp.checksum = calculate_ec_command_checksum(
+        &resp, sizeof(resp), resp_payload, actual_resp_size);
+
+    rv = fd_write_exact(STDOUT_FILENO, &resp, sizeof(resp));
+    if (rv) {
+      fprintf(stderr, "failed to write response header to stdout.\n");
+      return rv;
+    }
+
+    rv = fd_write_exact(STDOUT_FILENO, resp_payload, actual_resp_size);
+    if (rv) {
+      fprintf(stderr, "failed to write response payload to stdout.\n");
+      return rv;
+    }
+  }
+
+  return 0;
+}

--- a/examples/htool_raw_host_command.h
+++ b/examples/htool_raw_host_command.h
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_EXAMPLES_HTOOL_RAW_HOST_COMMAND_H_
+#define LIBHOTH_EXAMPLES_HTOOL_RAW_HOST_COMMAND_H_
+
+#include <stdint.h>
+
+struct htool_invocation;
+int command_raw_host_command(const struct htool_invocation* inv);
+
+#endif

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -23,6 +23,7 @@ executable(
     'htool_payload.c',
     'htool_payload_update.c',
     'htool_progress.c',
+    'htool_raw_host_command.c',
     'htool_spi.c',
     'htool_spi_proxy.c',
     'htool_statistics.c',


### PR DESCRIPTION
`htool raw_host_command` will read host command requests from `stdin`, execute them on the hoth device, and emit the resulting host command responses to `stdout`.

For example, we can execute `EC_CMD_HELLO` with `in_data == 0xa0b0c0d0`

```c
#define EC_CMD_HELLO 0x0001

struct ec_params_hello {
  // Pass anything here
  uint32_t in_data;
} __ec_align4;


struct ec_host_request {
  // Should be EC_HOST_REQUEST_VERSION
  uint8_t struct_version;
  // Checksum of request and data; sum of all bytes including checksum should
  // total to 0.
  uint8_t checksum;
  // Command to send (EC_CMD_...)
  uint16_t command;
  // Command version
  uint8_t command_version;
  uint8_t reserved;
  // Length of data that follows this header
  uint16_t data_len;
} __ec_align4;
```

by directly passing bytes of the request header and payload:
```
$ echo -ne '\x03\x18\x01\x00\x00\x00\x04\x00\xd0\xc0\xb0\xa0' | htool raw_host_command | hexdump -C
00000000  03 0f 00 00 04 00 00 00  d4 c3 b2 a1              |............|
```
Giving us the expected response of `0xa1b2c3d4`, as described in the response payload:

```c
struct ec_response_hello {
  // Output will be in_data + 0x01020304.
  uint32_t out_data;
} __ec_align4;
```

A remote client can invoke `htool raw_host_command` through SSH to write and read requests and responses, thus allowing `htool` to perform operations that aren't implemented in the CLI.