### PR TITLE
htool: don't print help msg when channel param is optional and missing

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -458,8 +458,12 @@ static int command_console(const struct htool_invocation* inv) {
       return -1;
     }
   } else {
-    // Channel is optional in snapshot mode: 0 = legacy host command.
-    if (htool_get_param_u32_or_fourcc(inv, "channel", &opts.channel_id)) {
+    if (htool_has_param(inv, "channel")) {
+      if (htool_get_param_u32_or_fourcc(inv, "channel", &opts.channel_id)) {
+        return -1;
+      }
+    } else {
+      // Channel is optional in snapshot mode: 0 = legacy host command.
       opts.channel_id = 0;
     }
   }

--- a/examples/htool_cmd.c
+++ b/examples/htool_cmd.c
@@ -154,6 +154,10 @@ static const char* get_param(const struct htool_invocation* inv,
   return param_info.param->default_value;
 }
 
+bool htool_has_param(const struct htool_invocation* inv, const char* name) {
+  return get_param(inv, name) != NULL;
+}
+
 static const char* get_param_required(const struct htool_invocation* inv,
                                       const char* name) {
   const char* result = get_param(inv, name);

--- a/examples/htool_cmd.h
+++ b/examples/htool_cmd.h
@@ -56,6 +56,8 @@ struct htool_invocation {
   const char** args;
 };
 
+bool htool_has_param(const struct htool_invocation* inv, const char* name);
+
 int htool_get_param_bool(const struct htool_invocation* inv, const char* name,
                          bool* value);
 int htool_get_param_u32(const struct htool_invocation* inv, const char* name,


### PR DESCRIPTION
`htool console` supports these flags:
```
  -c --channel
        Which channel to talk to. Typically a fourcc code.
  -s --snapshot (default: "false")
        Print a snapshot of most recent console messages.
```
Those flags can be combined. Here's the intended behavior:

|             |            **no `-s`**           |        **`-s`**        |
|-------------|:--------------------------------:|:----------------------:|
| **no `-c`** | print help msg: `-c` is required | print Hoth console log |
|   **`-c`**  | open live UART console           | print UART console log |

There's a bug with the "no `-c`" + "`-s`" case: htool emits an error message saying the channel is missing.

```
$ htool console -s
Unspecified required flag: --channel (or -c)
Usage: console
...snip usage text...
hoth console log
```

As described in the above table, the channel is not required for this case. This PR fixes this bug.