### PR TITLE
Conditionally compile D-Bus backend

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -60,6 +60,7 @@ cc_library(
     srcs = ["libhoth_dbus.c"],
     hdrs = ["libhoth_dbus.h"],
     linkopts = ["-lsystemd"],
+    defines = ["DBUS_BACKEND"],
     deps = [
         ":libhoth",
     ],

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -32,6 +32,13 @@ cc_library(
     deps = [":host_commands"],
 )
 
+config_setting(
+    name = "dbus_backend",
+    define_values = {
+        "dbus_backend": "true",
+    },
+)
+
 cc_binary(
     name = "htool",
     srcs = [
@@ -80,7 +87,9 @@ cc_binary(
         "//:libhoth_mtd",
         "//:libhoth_spi",
         "//:libhoth_usb",
-        "//:libhoth_dbus",
         "@libusb//:libusb",
-    ],
+    ] + select({
+        ":dbus_backend" : ["//:libhoth_dbus"],
+        "//conditions:default": [],
+    })
 )

--- a/examples/htool_dbus.c
+++ b/examples/htool_dbus.c
@@ -14,6 +14,8 @@
 // limitations under the License.
 #include <stdio.h>
 
+#ifdef DBUS_BACKEND
+
 #include "../libhoth_dbus.h"
 #include "htool_cmd.h"
 
@@ -43,3 +45,12 @@ struct libhoth_device* htool_libhoth_dbus_device(void) {
 
   return result;
 }
+
+#else
+
+struct libhoth_device* htool_libhoth_dbus_device(void) {
+  fprintf(stderr, "This build doesn't have the D-Bus backend.\n");
+  return NULL;
+}
+
+#endif  // DBUS_BACKEND

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -9,6 +9,14 @@ git_version_h = vcs_tag(
   replace_string: '@GIT_COMMIT@',
 )
 
+link_with = [libhoth]
+c_args = []
+
+if get_option('dbus_backend')
+  link_with += libhoth_dbus
+  c_args += '-DDBUS_BACKEND'
+endif
+
 executable(
   'htool',
   sources: [
@@ -34,5 +42,6 @@ executable(
     'srtm.c',
     git_version_h],
   dependencies: [libusb],
-  link_with: [libhoth],
+  link_with: link_with,
+  c_args: c_args,
   install: true)

--- a/meson.build
+++ b/meson.build
@@ -7,12 +7,16 @@ libhoth_srcs = [
   'libhoth_spi.c',
   'libhoth_usb_fifo.c',
   'libhoth_usb_mailbox.c',
-  'libhoth_dbus.c',
 ]
-libusb = dependency('libusb-1.0')
+
 libsystemd = dependency('libsystemd')
-libhoth = library('hoth', libhoth_srcs, dependencies: [libusb, libsystemd], install: true, \
+libhoth_dbus = static_library('hoth_dbus', 'libhoth_dbus.c', dependencies: [libsystemd])
+
+libusb = dependency('libusb-1.0')
+
+libhoth = library('hoth', libhoth_srcs, dependencies: [libusb], install: true, \
     version: meson.project_version())
+
 install_headers('libhoth.h')
 install_headers('libhoth_usb.h')
 install_headers('libhoth_usb_device.h')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('dbus_backend', type : 'boolean', value : false, description: 'Enable the D-Bus backend to use hothd as the transport')


### PR DESCRIPTION
A statically linked build of `htool` with the D-Bus backend fails to compile because of the `libsystemd` dependency. This PR  makes the D-Bus backend conditional at compile time.

## Bazel (`--define dbus_backend=true`)
```
$ bazel build ...

$ bazel-bin/examples/htool --transport dbus show chipinfo
This build doesn't have the D-Bus backend.

$ bazel build --define dbus_backend=true ...

$ bazel-bin/examples/htool --transport dbus show chipinfo
D-Bus call failed: The name xyz.openbmc_project.Control.Hoth was not provided by any .service files
libhoth_receive_response() failed: -113
```

## Meson (`configure -Ddbus_backend=true`)
```
$ meson setup builddir

$ (cd builddir && ninja) && builddir/examples/htool --transport dbus show chipinfo
This build doesn't have the D-Bus backend.

$ meson configure -Ddbus_backend=true builddir

$ (cd builddir && ninja) && builddir/examples/htool --transport dbus show chipinfo
D-Bus call failed: The name xyz.openbmc_project.Control.Hoth was not provided by any .service files
libhoth_receive_response() failed: -113
```