### PR TITLE
Fix formatting of authorization record.

### DIFF
--- a/examples/authorization_record.c
+++ b/examples/authorization_record.c
@@ -26,7 +26,7 @@ int authorization_record_print_hex_string(
     return -1;
   }
   int i;
-  const char* buf = (const char*)record;
+  const uint8_t* buf = (const uint8_t*)record;
   for (i = 0; i < sizeof(*record); ++i) {
     printf("%02x", buf[i]);
   }

--- a/examples/authorization_record.h
+++ b/examples/authorization_record.h
@@ -45,6 +45,11 @@ struct authorization_record {
 #define AUTHORIZATION_RECORD_MAGIC ("AUTHZREC")
 #define AUTHORIZATION_RECORD_SIZE (sizeof(struct authorization_record))
 
+// Note that changing the size of this structure may cause compatability issues;
+// the authorization infrastructure expects the above structure format.
+_Static_assert(AUTHORIZATION_RECORD_SIZE == 464,
+               "unexpected authorization_record size");
+
 int authorization_record_print_hex_string(
     const struct authorization_record* record);
 


### PR DESCRIPTION
Some systems consider `char` to be signed by default, which causes the system implementation of `printf("%02x", (char)0xd6);` to print `ffffffd6`, instead of just `d6`.  As the nonce almost always has "negative" bytes, this badly corrupts the record formatting.

Also add a _Static_assert for the exact size of the authorization record, for good measure.