### PR TITLE
Run clang-include-cleaner on files.

### DIFF
--- a/examples/htool_i2c.c
+++ b/examples/htool_i2c.c
@@ -15,6 +15,7 @@
 #include "htool_i2c.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/htool_raw_host_command.c
+++ b/examples/htool_raw_host_command.c
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/libhoth_dbus.c
+++ b/libhoth_dbus.c
@@ -14,7 +14,10 @@
 
 #include "libhoth_dbus.h"
 
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <systemd/sd-bus.h>
 
 #include "libhoth.h"


### PR DESCRIPTION
Fixes some standard library headers that were used but not specified.