### PR TITLE
Hex dump command response on checksum failure

### DIFF
--- a/examples/ec_util.c
+++ b/examples/ec_util.c
@@ -14,11 +14,11 @@
 
 #include "ec_util.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <ctype.h>
 
 uint8_t calculate_ec_command_checksum(const void* header, size_t header_size,
                                       const void* data, size_t data_size) {
@@ -107,6 +107,10 @@ int validate_ec_response_header(const struct ec_host_response* response_header,
   // should be zero.
   if (response_checksum != 0) {
     fprintf(stderr, "Error: response checksum (%u) != 0\n", response_checksum);
+    fprintf(stderr, "Response header:\n");
+    hex_dump(stderr, response_header, sizeof(*response_header));
+    fprintf(stderr, "Response body:\n");
+    hex_dump(stderr, response, response_header->data_len);
     return -EINVAL;
   }
 
@@ -137,7 +141,7 @@ void hex_dump(FILE* out, const void* buffer, size_t size) {
 
       if (i < chunk_size) {
         uint8_t byte = bytes[offset + i];
-        fprintf(out, "%02X ", byte);
+        fprintf(out, "%02x ", byte);
         line_ascii[i] = isgraph(byte) ? byte : '.';
       } else {
         fprintf(out, "   ");  // filler instead of hex digits
@@ -148,4 +152,3 @@ void hex_dump(FILE* out, const void* buffer, size_t size) {
     fprintf(out, "|%s|\n", line_ascii);
   }
 }
-

--- a/examples/ec_util.h
+++ b/examples/ec_util.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "host_commands.h"
 
@@ -33,6 +34,8 @@ int populate_ec_request_header(uint16_t command, uint8_t command_version,
 
 int validate_ec_response_header(const struct ec_host_response* response_header,
                                 const void* response, size_t response_size);
+
+void hex_dump(FILE* out, const void* buffer, size_t size);
 
 #ifdef __cplusplus
 }

--- a/examples/htool_panic.c
+++ b/examples/htool_panic.c
@@ -20,10 +20,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ec_util.h"
 #include "host_commands.h"
 #include "htool.h"
 #include "htool_cmd.h"
-#include "ec_util.h"
 
 static int check_expected_response_length(uint16_t length, uint16_t expected) {
   if (length != expected) {


### PR DESCRIPTION
The dump helps us debug why the response checksum is bad.

Example sending `EC_CMD_HELLO` with a corrupted response body:
```
$ echo -ne '\x03\x18\x01\x00\x00\x00\x04\x00\xd0\xc0\xb0\xa0' | htool raw_host_command
Error: response checksum (255) != 0
Response header:
0x0000: 03 0f 00 00 04 00 00 00                          |........        |
Response body:
0x0000: d5 c3 b2 a1                                      |....            |
EC response header invalid: -22
```