### PR TITLE
Add --spidev_atomic.

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -957,6 +957,10 @@ static const struct htool_param GLOBAL_FLAGS[] = {
     {HTOOL_FLAG_VALUE, .name = "spidev_path", .default_value = "",
      .desc = "The full SPIDEV path of the RoT; for example "
              "'/dev/spidev0.0'."},
+    {HTOOL_FLAG_BOOL, .name = "spidev_atomic", .default_value = "false",
+     .desc = "If true, force spidev to send the request and receive the "
+             "corresponding response with a single atomic ioctl.  This is "
+             "required on some systems for correctness."},
     {HTOOL_FLAG_VALUE, .name = "mtddev_path", .default_value = "",
      .desc = "The full MTD path of the RoT mailbox; for example "
              "'/dev/mtd0'. If unspecified, will attempt to detect "

--- a/examples/htool_spi.c
+++ b/examples/htool_spi.c
@@ -34,10 +34,12 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
   int rv;
   const char* spidev_path_str;
   uint32_t mailbox_location;
+  bool atomic;
   rv = htool_get_param_string(htool_global_flags(), "spidev_path",
                               &spidev_path_str) ||
        htool_get_param_u32(htool_global_flags(), "mailbox_location",
-                           &mailbox_location);
+                           &mailbox_location) ||
+       htool_get_param_bool(htool_global_flags(), "spidev_atomic", &atomic);
   if (rv) {
     return NULL;
   }
@@ -47,8 +49,11 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
     return NULL;
   }
 
-  struct libhoth_spi_device_init_options opts = {.path = spidev_path_str,
-                                                 .mailbox = mailbox_location};
+  struct libhoth_spi_device_init_options opts = {
+      .path = spidev_path_str,
+      .mailbox = mailbox_location,
+      .atomic = atomic,
+  };
   rv = libhoth_spi_open(&opts, &result);
   if (rv) {
     // TODO: Convert error-code to a string

--- a/libhoth_spi.c
+++ b/libhoth_spi.c
@@ -253,7 +253,7 @@ int libhoth_spi_receive_response(struct libhoth_device* dev, void* response,
     return LIBHOTH_ERR_INVALID_PARAMETER;
   }
 
-  if (max_response_size < 8) {
+  if (max_response_size < sizeof(struct ec_host_response)) {
     return LIBHOTH_ERR_INVALID_PARAMETER;
   }
 
@@ -265,12 +265,13 @@ int libhoth_spi_receive_response(struct libhoth_device* dev, void* response,
 
   // Read Header From Mailbox
   status = spi_nor_read(spi_dev->fd, spi_dev->address_mode_4b,
-                        spi_dev->mailbox_address, response, 8);
+                        spi_dev->mailbox_address, response,
+                        sizeof(struct ec_host_response));
   if (status != LIBHOTH_OK) {
     return status;
   }
 
-  total_bytes = 8;
+  total_bytes = sizeof(struct ec_host_response);
   memcpy(&host_response, response, sizeof(host_response));
   if (actual_size) {
     *actual_size = total_bytes;
@@ -324,7 +325,7 @@ int libhoth_spi_send_and_receive_response(struct libhoth_device* dev,
     return LIBHOTH_ERR_INVALID_PARAMETER;
   }
 
-  if (max_response_size < 8) {
+  if (max_response_size < sizeof(struct ec_host_response)) {
     return LIBHOTH_ERR_INVALID_PARAMETER;
   }
 
@@ -390,7 +391,8 @@ int libhoth_spi_send_and_receive_response(struct libhoth_device* dev,
     if (actual_size) {
       struct ec_host_response* host_response =
           (struct ec_host_response*)response;
-      *actual_size = (size_t)host_response->data_len + 8;
+      *actual_size =
+          (size_t)host_response->data_len + sizeof(struct ec_host_response);
     }
   }
 

--- a/libhoth_spi.h
+++ b/libhoth_spi.h
@@ -31,6 +31,7 @@ struct libhoth_spi_device_init_options {
   int bits;
   int mode;
   int speed;
+  int atomic;
 };
 
 // Note that the options struct only needs to to live for the duration of


### PR DESCRIPTION
Some systems have special-purpose spidev drivers that can only enforce atomicity of the mailbox request if the entire SPI transaction sequence (write followed by read) is given as a single atomic `ioctl`.  Add the --spidev_atomic flag to enable this special-case behavior.