### PR TITLE
Add support for controlling I2C Mux connected to target (if present)

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -72,6 +72,8 @@ cc_binary(
         "htool_spi_proxy.h",
         "htool_statistics.c",
         "htool_statistics.h",
+        "htool_target_control.c",
+        "htool_target_control.h",
         "htool_update_failure_reasons.h",
         "htool_usb.c",
         "htool_usb.h",

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -674,6 +674,50 @@ struct ec_response_i2c_transfer {
   uint8_t resp_bytes[I2C_TRANSFER_DATA_MAX_SIZE_BYTES];
 } __attribute__((packed, aligned(4)));
 
+/* Control miscellaneous boolean functions on target */
+#define EC_PRV_CMD_HOTH_TARGET_CONTROL 0x0047
+
+/* Options and request struct for EC_PRV_CMD_HOTH_TARGET_CONTROL */
+enum ec_target_control_action {
+  // Returns the current enabled/disabled status of the given function.
+  EC_TARGET_CONTROL_ACTION_GET_STATUS = 0,
+
+  // Changes the status of the given function to "Disabled". Returns the
+  // previous enabled/disabled status of the given function.
+  EC_TARGET_CONTROL_ACTION_DISABLE = 1,
+
+  // Changes the status of the given function to "Enabled". Returns the previous
+  // enabled/disabled status of the given function.
+  EC_TARGET_CONTROL_ACTION_ENABLE = 2,
+};
+
+enum ec_target_control_function {
+  EC_TARGET_CONTROL_RESERVED0 = 0,
+  EC_TARGET_CONTROL_RESERVED1 = 1,
+  // Allow control over GPIO for I2C Mux select (if present)
+  EC_TARGET_CONTROL_I2C_MUX = 2,
+};
+
+enum ec_target_control_status {
+  EC_TARGET_CONTROL_STATUS_UNKNOWN = 0,
+  EC_TARGET_CONTROL_STATUS_DISABLED = 1,
+  EC_TARGET_CONTROL_STATUS_ENABLED = 2,
+};
+
+struct ec_request_target_control {
+  uint16_t function;  // must be ec_target_control_function
+  uint16_t action;    // must be ec_target_control_action
+  uint8_t args[];     // function+action specific args. Unused right now
+} __attribute__((packed, aligned(4)));
+
+struct ec_response_target_control {
+  // If the action changes the target control status, returns the status prior
+  // to the change requested by the host command.
+  //
+  // Must be ec_target_control_status
+  uint16_t status;
+} __attribute__((packed, aligned(4)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -936,6 +936,27 @@ static const struct htool_cmd CMDS[] = {
         .func = htool_i2c_run,
     },
     {
+        .verbs = (const char*[]){"i2c", I2C_MUXCTRL_CMD_STR,
+                                 I2C_MUXCTRL_GET_SUBCMD_STR, NULL},
+        .desc = "Get status of I2C Mux sel (if present)",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_i2c_muxctrl_get,
+    },
+    {
+        .verbs = (const char*[]){"i2c", I2C_MUXCTRL_CMD_STR,
+                                 I2C_MUXCTRL_SELECT_TARGET_SUBCMD_STR, NULL},
+        .desc = "Change I2C Mux sel (if present) to select Target",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_i2c_muxctrl_select_target,
+    },
+    {
+        .verbs = (const char*[]){"i2c", I2C_MUXCTRL_CMD_STR,
+                                 I2C_MUXCTRL_SELECT_HOST_SUBCMD_STR, NULL},
+        .desc = "Change I2C Mux sel (if present) to select Host",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_i2c_muxctrl_select_host,
+    },
+    {
         .verbs = (const char*[]){"raw_host_command", NULL},
         .desc = "Stream raw host commands via stdin/stdout",
         .params = (const struct htool_param[]){{}},

--- a/examples/htool_target_control.c
+++ b/examples/htool_target_control.c
@@ -1,0 +1,60 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "htool_target_control.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "host_commands.h"
+#include "htool.h"
+
+int target_control_perform_action(
+    const enum ec_target_control_function function,
+    const enum ec_target_control_action action,
+    struct ec_response_target_control* const response) {
+  if (response == NULL) {
+    return -1;
+  }
+
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  const struct ec_request_target_control request = {
+      .function = function,
+      .action = action,
+  };
+
+  size_t response_length = 0;
+  int ret = htool_exec_hostcmd(
+      dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_TARGET_CONTROL,
+      /*version=*/0, &request, sizeof(request), response, sizeof(*response),
+      &response_length);
+
+  if (ret != 0) {
+    fprintf(stderr, "HOTH_TARGET_CONTROL error code: %d\n", ret);
+    return -1;
+  }
+  if (response_length != sizeof(*response)) {
+    fprintf(
+        stderr,
+        "HOTH_TARGET_CONTROL expected exactly %zu response bytes, got %zu\n",
+        sizeof(*response), response_length);
+    return -1;
+  }
+
+  return 0;
+}

--- a/examples/htool_target_control.h
+++ b/examples/htool_target_control.h
@@ -1,3 +1,4 @@
+
 // Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,31 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBHOTH_EXAMPLES_HTOOL_I2C_H_
-#define LIBHOTH_EXAMPLES_HTOOL_I2C_H_
+#ifndef LIBHOTH_EXAMPLES_HTOOL_TARGET_CONTROL_H_
+#define LIBHOTH_EXAMPLES_HTOOL_TARGET_CONTROL_H_
 
+#include "host_commands.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define I2C_DETECT_CMD_STR "detect"
-#define I2C_READ_CMD_STR "read"
-#define I2C_WRITE_CMD_STR "write"
-#define I2C_MUXCTRL_CMD_STR "mux_ctrl"
-#define I2C_MUXCTRL_GET_SUBCMD_STR "get"
-#define I2C_MUXCTRL_SELECT_TARGET_SUBCMD_STR "select_target"
-#define I2C_MUXCTRL_SELECT_HOST_SUBCMD_STR "select_host"
-
-// Forward declaration
-struct htool_invocation;
-
-int htool_i2c_run(const struct htool_invocation* inv);
-
-int htool_i2c_muxctrl_get(const struct htool_invocation* inv);
-
-int htool_i2c_muxctrl_select_target(const struct htool_invocation* inv);
-
-int htool_i2c_muxctrl_select_host(const struct htool_invocation* inv);
+int target_control_perform_action(enum ec_target_control_function function,
+                                  enum ec_target_control_action action,
+                                  struct ec_response_target_control* response);
 
 #ifdef __cplusplus
 }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -37,6 +37,7 @@ executable(
     'htool_spi.c',
     'htool_spi_proxy.c',
     'htool_statistics.c',
+    'htool_target_control.c',
     'htool_usb.c',
     'htool_srtm.h',
     'htool_srtm.c',


### PR DESCRIPTION
Add support for htool to control select pin on I2C Mux (if one is connected to the target). This is based on generic "Target Control" functionality that allows controlling miscellaneous boolean functions on the target.