### PR TITLE
Add `authz_host_command build/send`

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -49,6 +49,8 @@ cc_binary(
         "host_commands.h",
         "htool.c",
         "htool.h",
+        "htool_authz_command.h",
+        "htool_authz_command.c",
         "htool_cmd.c",
         "htool_cmd.h",
         "htool_console.c",

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -477,6 +477,31 @@ struct ec_authz_record_get_nonce_response {
   uint32_t rw_supported_key_id;
 } __attribute__((packed));
 
+#define AUTHORIZED_COMMAND_SIGNATURE_SIZE 64
+#define AUTHORIZED_COMMAND_NONCE_SIZE 32
+#define AUTHORIZED_COMMAND_VERSION 1
+
+#define EC_PRV_CMD_HOTH_GET_AUTHZ_COMMAND_NONCE 0x0035
+
+struct ec_authorized_command_get_nonce_response {
+  uint32_t nonce[AUTHORIZED_COMMAND_NONCE_SIZE / sizeof(uint32_t)];
+  uint32_t supported_key_info;
+} __attribute__((packed, aligned(4)));
+
+#define EC_PRV_CMD_HOTH_AUTHZ_COMMAND 0x0034
+
+struct ec_authorized_command_request {
+  uint8_t signature[AUTHORIZED_COMMAND_SIGNATURE_SIZE];
+  uint32_t version;
+  uint32_t size;
+  uint32_t key_info;
+  uint32_t dev_id_0;
+  uint32_t dev_id_1;
+  uint32_t nonce[AUTHORIZED_COMMAND_NONCE_SIZE / sizeof(uint32_t)];
+  uint32_t opcode;
+  uint32_t arg_bytes[];
+} __attribute__((packed, aligned(4)));
+
 #define MAILBOX_SIZE 1024
 
 #define EC_PRV_CMD_HOTH_PAYLOAD_UPDATE 0x0005

--- a/examples/htool_authz_command.c
+++ b/examples/htool_authz_command.c
@@ -1,0 +1,95 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "host_commands.h"
+
+struct ec_authorized_command_request authz_command_build_request(
+    uint64_t hardware_identity, uint32_t opcode, uint32_t key_info,
+    const uint32_t* nonce) {
+  struct ec_authorized_command_request request = {
+      .version = AUTHORIZED_COMMAND_VERSION,
+      .size = sizeof(request),
+      .key_info = key_info,
+      .dev_id_0 = hardware_identity & UINT32_C(0xffffffff),
+      .dev_id_1 = hardware_identity >> 32,
+      .opcode = opcode,
+  };
+  memcpy(request.nonce, nonce, sizeof(request.nonce));
+  return request;
+}
+
+void authz_command_print_request(
+    const struct ec_authorized_command_request* request) {
+  const uint8_t* out = (const uint8_t*)request;
+  for (int i = 0; i < sizeof(*request); i++) {
+    printf("%02x", out[i]);
+  }
+  printf("\n");
+}
+
+static uint8_t parse_nibble(char c) {
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+  if (c >= 'a' && c <= 'f') {
+    return c - 'a' + 0xa;
+  }
+  if (c >= 'A' && c <= 'F') {
+    return c - 'A' + 0xa;
+  }
+  return UINT8_MAX;
+}
+
+int authz_command_hex_to_struct(const char* hexstring,
+                                struct ec_authorized_command_request* request) {
+  size_t actual_len = strlen(hexstring);
+  size_t expected_len = 2 * sizeof(*request);
+  if (actual_len != expected_len) {
+    fprintf(stderr, "Bad hexstring length. Got %ld but expected %ld.\n",
+            actual_len, expected_len);
+    if (actual_len > expected_len) {
+      fprintf(stderr, "Note: command payloads are unsupported.\n");
+    }
+    return -1;
+  }
+
+  uint8_t* out = (uint8_t*)request;
+
+  for (int i = 0; i < sizeof(*request); i++) {
+    uint8_t nibble_0 = parse_nibble(hexstring[2 * i]);
+    uint8_t nibble_1 = parse_nibble(hexstring[2 * i + 1]);
+    if (nibble_0 == UINT8_MAX || nibble_1 == UINT8_MAX) {
+      fprintf(stderr, "Invalid hex character at byte %d\n", i);
+      return -1;
+    }
+    out[i] = (nibble_0 << 4) | nibble_1;
+  }
+
+  bool has_payload = request->size > sizeof(*request);
+  if (has_payload) {
+    uint32_t payload_size = request->size - sizeof(*request);
+    fprintf(stderr,
+            "Command payloads are unsupported. Request declares a payload of "
+            "size %d bytes.\n",
+            payload_size);
+    return -1;
+  }
+
+  return 0;
+}

--- a/examples/htool_authz_command.h
+++ b/examples/htool_authz_command.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_EXAMPLES_AUTHZ_COMMAND_H_
+#define LIBHOTH_EXAMPLES_AUTHZ_COMMAND_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ec_authorized_command_request;
+
+struct ec_authorized_command_request authz_command_build_request(
+    uint64_t hardware_identity, uint32_t opcode, uint32_t key_info,
+    const uint32_t* nonce);
+
+void authz_command_print_request(
+    const struct ec_authorized_command_request* request);
+
+int authz_command_hex_to_struct(const char* hexstring,
+                                struct ec_authorized_command_request* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LIBHOTH_EXAMPLES_AUTHZ_COMMAND_H_

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -24,6 +24,7 @@ executable(
     'authorization_record.c',
     'ec_util.c',
     'htool.c',
+    'htool_authz_command.c',
     'htool_cmd.c',
     'htool_console.c',
     'htool_dbus.c',


### PR DESCRIPTION
Adds two commands:
1. `htool authz_host_command build OPCODE`
2. `htool authz_host_command send COMMAND_BYTES`

Example usage:
```
$ htool authz_host_command build 1
0000000000000000...

$ htool authz_host_command send cdf93af5308e4a71...
```