### PR TITLE
Seed random number generator used for generating request IDs when sending requests over FIFO based USB transport

### DIFF
--- a/examples/htool_usb.c
+++ b/examples/htool_usb.c
@@ -331,7 +331,7 @@ struct libhoth_device* htool_libhoth_usb_device(void) {
   // systems. But it may have implementation defined resolution. So xor with PID
   // as well
   if (clock_gettime(CLOCK_MONOTONIC, &monotonic_time) != 0) {
-    fprintf(stderr, "Could not get clock time to generate PRNG seed");
+    fprintf(stderr, "Could not get clock time to generate PRNG seed\n");
     return NULL;
   }
   uint32_t prng_seed =

--- a/examples/htool_usb.c
+++ b/examples/htool_usb.c
@@ -337,9 +337,8 @@ struct libhoth_device* htool_libhoth_usb_device(void) {
   uint32_t prng_seed =
       monotonic_time.tv_sec ^ monotonic_time.tv_nsec ^ getpid();
 
-  struct libhoth_usb_device_init_options opts = {.usb_device = usb_dev,
-                                                 .usb_ctx = ctx,
-                                                 .prng_seed = prng_seed};
+  struct libhoth_usb_device_init_options opts = {
+      .usb_device = usb_dev, .usb_ctx = ctx, .prng_seed = prng_seed};
 
   int rv = libhoth_usb_open(&opts, &result);
   if (rv) {

--- a/libhoth_usb.c
+++ b/libhoth_usb.c
@@ -142,7 +142,8 @@ int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
       status = libhoth_usb_mailbox_open(usb_dev, config_descriptor);
       break;
     case LIBHOTH_USB_INTERFACE_TYPE_FIFO:
-      status = libhoth_usb_fifo_open(usb_dev, config_descriptor, options->prng_seed);
+      status =
+          libhoth_usb_fifo_open(usb_dev, config_descriptor, options->prng_seed);
       break;
     default:
       status = LIBHOTH_ERR_INTERFACE_NOT_FOUND;

--- a/libhoth_usb.c
+++ b/libhoth_usb.c
@@ -142,7 +142,7 @@ int libhoth_usb_open(const struct libhoth_usb_device_init_options* options,
       status = libhoth_usb_mailbox_open(usb_dev, config_descriptor);
       break;
     case LIBHOTH_USB_INTERFACE_TYPE_FIFO:
-      status = libhoth_usb_fifo_open(usb_dev, config_descriptor);
+      status = libhoth_usb_fifo_open(usb_dev, config_descriptor, options->prng_seed);
       break;
     default:
       status = LIBHOTH_ERR_INTERFACE_NOT_FOUND;

--- a/libhoth_usb.h
+++ b/libhoth_usb.h
@@ -17,6 +17,7 @@
 
 #include <libusb.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +31,9 @@ struct libhoth_usb_device_init_options {
   // The libusb context to use for operations. Can be NULL for the default
   // context.
   libusb_context* usb_ctx;
+  // Seed value to use for Pseudo-random number generator for communicating with
+  // RoT over USB FIFO interface
+  uint32_t prng_seed;
 };
 
 // Note that the options struct only needs to to live for the duration of

--- a/libhoth_usb_device.h
+++ b/libhoth_usb_device.h
@@ -59,6 +59,7 @@ struct libhoth_usb_fifo {
   int all_transfers_completed;
   bool in_transfer_completed;
   bool out_transfer_completed;
+  uint32_t prng_state;
 };
 
 struct libhoth_usb_interface_info {
@@ -78,7 +79,8 @@ struct libhoth_usb_device {
 };
 
 int libhoth_usb_fifo_open(struct libhoth_usb_device *dev,
-                          const struct libusb_config_descriptor *descriptor);
+                          const struct libusb_config_descriptor *descriptor,
+                          uint32_t prng_seed);
 int libhoth_usb_fifo_send_request(struct libhoth_usb_device *dev,
                                   const void *request, size_t request_size);
 int libhoth_usb_fifo_receive_response(struct libhoth_usb_device *dev,

--- a/libhoth_usb_fifo.c
+++ b/libhoth_usb_fifo.c
@@ -84,7 +84,7 @@ static void fifo_transfer_callback(struct libusb_transfer *transfer) {
 }
 
 // 32-bits XOR shift algorithm from "Xorshift RNGs" by George Marsaglia
-uint32_t libhoth_generate_pseudorandom_u32(uint32_t *seed) {
+static uint32_t libhoth_generate_pseudorandom_u32(uint32_t *seed) {
   *seed ^= (*seed << 13);
   // The paper seems to have a typo in the algorithm presented on Pg 4, missing
   // the ^ operation for second assignment. Pg 3 shows 8 shift operations that


### PR DESCRIPTION
This change adds new field in `libhoth_usb_device_init_options` which MUST be filled by an application to set a seed for generating pseudo random numbers in libhoth USB FIFO library. An implementation of 32-bit XORshift algorithm is added in libhoth USB FIFO library to generate pseudo-random bytes for request IDs used to synchronize response from RoT. htool is updated to set PRNG seed before calling libhoth device open API.