### PR TITLE
Add support to request program and/or verify operation for PLD connected to RoT

### DIFF
--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -431,6 +431,8 @@ enum ec_jtag_operation {
   EC_JTAG_OP_UNDEFINED = 0,
   EC_JTAG_OP_READ_IDCODE = 1,
   EC_JTAG_OP_TEST_BYPASS = 2,
+  EC_JTAG_OP_PROGRAM_AND_VERIFY_PLD = 3,
+  EC_JTAG_OP_VERIFY_PLD = 4,
 };
 
 struct ec_request_jtag_operation {
@@ -449,6 +451,16 @@ struct ec_request_jtag_test_bypass_operation {
   // Test pattern to send over TDI with `EC_JTAG_OP_TEST_BYPASS`
   uint8_t tdi_pattern[EC_JTAG_TEST_BYPASS_PATTERN_LEN];
 };
+
+struct ec_request_jtag_program_and_verify_pld_operation {
+  // Offset in external flash where data to program and verify PLD is stored
+  uint32_t data_offset;
+} __attribute__((packed, aligned(4)));
+
+struct ec_request_jtag_verify_pld_operation {
+  // Offset in external flash where data to verify PLD is stored
+  uint32_t data_offset;
+} __attribute__((packed, aligned(4)));
 
 // Separate response structures for each operation. Naming convention: `struct
 // ec_response_jtag_<op>_operation`

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -1071,6 +1071,34 @@ static const struct htool_cmd CMDS[] = {
         .params = (const struct htool_param[]){{}},
         .func = htool_external_usb_host_check_presence,
     },
+    {
+        .verbs =
+            (const char*[]){"jtag", JTAG_PROGRAM_AND_VERIFY_PLD_CMD_STR, NULL},
+        .desc = "Program and verify a PLD over JTAG. Assumes only a single "
+                "device in chain",
+        .params =
+            (const struct htool_param[]){
+                {.type = HTOOL_FLAG_VALUE,
+                 .ch = 'o',
+                 .name = "offset",
+                 .default_value = "0",
+                 .desc = "Offset to read program and verify data from"},
+                {}},
+        .func = command_jtag_operation_run,
+    },
+    {
+        .verbs = (const char*[]){"jtag", JTAG_VERIFY_PLD_CMD_STR, NULL},
+        .desc = "Verify a PLD over JTAG. Assumes only a single device in chain",
+        .params =
+            (const struct htool_param[]){
+                {.type = HTOOL_FLAG_VALUE,
+                 .ch = 'o',
+                 .name = "offset",
+                 .default_value = "0",
+                 .desc = "Offset to read verify data from"},
+                {}},
+        .func = command_jtag_operation_run,
+    },
     {},
 };
 

--- a/examples/htool_jtag.c
+++ b/examples/htool_jtag.c
@@ -22,6 +22,7 @@
 #include "host_commands.h"
 #include "htool.h"
 #include "htool_cmd.h"
+#include "protocol/host_cmd.h"
 
 char JTAG_TEST_BYPASS_PATTERN_DEFAULT_VALUE[] =
     // PRBS9 with '0' bit added at the beginning to make it exactly 64 bytes
@@ -214,7 +215,7 @@ static int jtag_program_and_verify_pld(struct libhoth_device *dev,
   };
 
   size_t response_length = 0;
-  int ret = htool_exec_hostcmd(
+  int ret = hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);
@@ -258,7 +259,7 @@ static int jtag_verify_pld(struct libhoth_device *dev,
   };
 
   size_t response_length = 0;
-  int ret = htool_exec_hostcmd(
+  int ret = hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);

--- a/examples/htool_jtag.h
+++ b/examples/htool_jtag.h
@@ -21,6 +21,8 @@ extern "C" {
 
 #define JTAG_READ_IDCODE_CMD_STR "read_idcode"
 #define JTAG_TEST_BYPASS_CMD_STR "test_bypass"
+#define JTAG_PROGRAM_AND_VERIFY_PLD_CMD_STR "program_and_verify_pld"
+#define JTAG_VERIFY_PLD_CMD_STR "verify_pld"
 
 // Forward declaration
 struct htool_invocation;


### PR DESCRIPTION
New CLI options added to request RoT to read PLD configuration from offset provided in the command and
- To program that configuration on the PLD
- To verify that configuration against the configuration on the PLD