### PR TITLE
Add payload inspection to htool/libhoth

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -71,6 +71,7 @@ cc_binary(
         "//protocol:authz_record",
         "//protocol:host_cmd",
         "//protocol:rot_firmware_version",
+        "//protocol:payload_info",
         "//protocol:payload_status",
         "//protocol:panic",
         "//protocol:payload_update",

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -764,6 +764,14 @@ static const struct htool_cmd CMDS[] = {
                 {HTOOL_POSITIONAL, .name = "source-file"}, {}},
         .func = htool_payload_update,
     },
+    {
+        .verbs = (const char*[]){"payload", "info", NULL},
+        .desc = "Display payload info for a Titan image.",
+        .params =
+            (const struct htool_param[]){
+                {HTOOL_POSITIONAL, .name = "source-file"}, {}},
+        .func = htool_payload_info,
+    },
     {.verbs = (const char*[]){"flash_spi_info", NULL},
      .desc = "Get SPI NOR flash info.",
      .params = (const struct htool_param[]){{}},

--- a/examples/htool_payload.h
+++ b/examples/htool_payload.h
@@ -17,11 +17,15 @@
 
 #include <stdint.h>
 
+#include "htool.h"
+#include "htool_cmd.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int htool_payload_status();
+int htool_payload_info(const struct htool_invocation* inv);
 
 #ifdef __cplusplus
 }

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -85,6 +85,7 @@ cc_library(
     deps = [
         "//transports:libhoth_device",
         ":host_cmd",
+        ":payload_info",
     ],
 )
 
@@ -231,7 +232,6 @@ cc_library(
     ],
 )
 
-
 cc_test(
     name = "spi_proxy_test",
     srcs = ["spi_proxy_test.cc"],
@@ -241,5 +241,24 @@ cc_test(
         "//transports:libhoth_device",
         "//protocol/test:libhoth_device_mock",
         ":spi_proxy",
+    ],
+)
+
+cc_library(
+    name = "payload_info",
+    hdrs = ["payload_info.h"],
+    srcs = ["payload_info.c"],
+)
+
+cc_test(
+    name = "payload_info_test",
+    srcs = ["payload_info_test.cc"],
+    deps = [
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        ":payload_info",
+    ],
+    data = [
+        "//protocol/test:test_data",
     ],
 )

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -11,6 +11,7 @@ protocol_srcs = [
   'authz_record.c',
   'progress.c',
   'spi_proxy.c',
+  'payload_info.c',
 ]
 
 incdir = include_directories('..')

--- a/protocol/payload_info.c
+++ b/protocol/payload_info.c
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "payload_info.h"
+
+#include <string.h>
+
+const struct image_descriptor* libhoth_find_image_descriptor(const uint8_t* image,
+                                                       size_t len) {
+  for (size_t off = 0; off + sizeof(struct image_descriptor) - 1 < len;
+       off += TITAN_IMAGE_DESCRIPTOR_ALIGNMENT) {
+    int64_t magic_candidate;
+    memcpy(&magic_candidate, image + off, sizeof(magic_candidate));
+    if (magic_candidate == TITAN_IMAGE_DESCRIPTOR_MAGIC) {
+      struct image_descriptor* img_dsc =
+          (struct image_descriptor*)(image + off);
+
+      if(img_dsc->descriptor_area_size + off > len) {
+        // Image descriptor is clipped
+        return NULL;
+      }
+
+      return img_dsc;
+    }
+  }
+  return NULL;
+}
+
+bool libhoth_payload_info(const uint8_t* image, size_t len,
+                          struct payload_info* payload_info) {
+  const struct image_descriptor* descr = libhoth_find_image_descriptor(image, len);
+  if (descr == NULL) {
+    return false;
+  }
+
+  memcpy(payload_info->image_name, descr->image_name,
+         sizeof(payload_info->image_name));
+  payload_info->image_name[sizeof(payload_info->image_name)-1] = 0;
+
+  payload_info->image_family = descr->image_family;
+  payload_info->image_version.major = descr->image_major;
+  payload_info->image_version.minor = descr->image_minor;
+  payload_info->image_version.point = descr->image_point;
+  payload_info->image_version.subpoint = descr->image_subpoint;
+  payload_info->image_type = descr->image_type;
+
+  if (descr->hash_type != HASH_SHA2_256) {
+    memset(payload_info->image_hash, 0, sizeof(payload_info->image_hash));
+  } else {
+    uint32_t region_size = descr->region_count * sizeof(struct image_region);
+    struct hash_sha256* hash =
+        (struct hash_sha256*)((uint8_t*)&descr->image_regions + region_size);
+    memcpy(payload_info->image_hash, hash->hash, sizeof(hash->hash));
+  }
+
+  return true;
+}

--- a/protocol/payload_info.h
+++ b/protocol/payload_info.h
@@ -1,0 +1,168 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_PROTOCOL_PAYLOAD_INFO_H_
+#define LIBHOTH_PROTOCOL_PAYLOAD_INFO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define TITAN_IMAGE_DESCRIPTOR_MAGIC 0x5f435344474d495f  // "_IMGDSC_"
+#define TITAN_IMAGE_DESCRIPTOR_ALIGNMENT (1 << 16)
+#define TITAN_IMAGE_DESCRIPTOR_HASH_MAGIC 0x48534148  // "HASH"
+
+enum image_type {
+  IMAGE_DEV = 0,
+  IMAGE_PROD = 1,
+  IMAGE_BREAKOUT = 2,
+  IMAGE_TEST = 3,
+  IMAGE_UNSIGNED_INTEGRITY = 4
+};
+
+enum hash_type {
+  HASH_NONE = 0,
+  HASH_SHA2_224 = 1,
+  HASH_SHA2_256 = 2,
+  HASH_SHA2_384 = 3,
+  HASH_SHA2_512 = 4,
+  HASH_SHA3_224 = 5,
+  HASH_SHA3_256 = 6,
+  HASH_SHA3_384 = 7,
+  HASH_SHA3_512 = 8
+};
+
+#define IMAGE_REGION_STATIC (1 << 0)
+#define IMAGE_REGION_COMPRESSED (1 << 1)
+#define IMAGE_REGION_WRITE_PROTECTED (1 << 2)
+#define IMAGE_REGION_PERSISTENT (1 << 4)
+#define IMAGE_REGION_PERSISTENT_RELOCATABLE (1 << 5)
+#define IMAGE_REGION_PERSISTENT_EXPANDABLE (1 << 6)
+#define IMAGE_REGION_OVERRIDE (1 << 7)
+#define IMAGE_REGION_OVERRIDE_ON_TRANSITION (1 << 8)
+#define IMAGE_REGION_MAILBOX (1 << 9)
+#define IMAGE_REGION_SKIP_BOOT_VALIDATION (1 << 10)
+#define IMAGE_REGION_EMPTY (1 << 11)
+
+#define HASH_SHA256_BYTES 32
+
+struct image_region {
+  uint8_t region_name[32];  // null-terminated ASCII string
+  uint32_t region_offset;   // read- and write- protected regions must be
+                            // aligned to IMAGE_REGION_PROTECTED_ALIGNMENT.
+                            // Other regions are also aligned which
+                            // simplifies their implementation.
+  uint32_t region_size;     // read- and write- protected regions must be a
+                            // multiple of IMAGE_REGION_PROTECTED_PAGE_LENGTH.
+  /* Regions will not be persisted across different versions.
+   * This field is intended to flag potential incompatibilities in the
+   * context of data migration (e.g. the ELOG format changed between
+   * two BIOS releases).
+   */
+  uint16_t region_version;
+  /* See IMAGE_REGION_* defines above. */
+  uint16_t region_attributes;
+} __attribute__((__packed__));
+
+/* Hash the static regions (IMAGE_REGION_STATIC) excluding this descriptor
+ * structure i.e. skipping image_descriptor.descriptor_size bytes (optional).
+ */
+struct hash_sha256 {
+  uint32_t hash_magic;  // #define TITAN_IMAGE_DESCRIPTOR_HASH_MAGIC
+  uint8_t hash[HASH_SHA256_BYTES];
+} __attribute__((__packed__));
+
+struct hash_sha512 {
+  uint32_t hash_magic;  // #define TITAN_IMAGE_DESCRIPTOR_HASH_MAGIC
+  uint8_t hash[64];
+} __attribute__((__packed__));
+
+struct image_descriptor {
+  uint64_t descriptor_magic;
+  uint8_t descriptor_major;
+  uint8_t descriptor_minor;
+  uint16_t reserved_0;
+
+  uint32_t descriptor_offset;
+  uint32_t descriptor_area_size;
+
+  uint8_t image_name[32];
+  uint32_t image_family;
+
+  /* Follow the Kibbles versioning scheme. */
+  uint32_t image_major;
+  uint32_t image_minor;
+  uint32_t image_point;
+  uint32_t image_subpoint;
+
+  /* Seconds since epoch. */
+  uint64_t build_timestamp;
+
+  /* image_type enum { DEV, PROD, BREAKOUT, UNSIGNED_INTEGRITY} */
+  uint8_t image_type;
+
+  uint8_t reserved_3;
+
+  /* hash_type enum { NONE, SHA2_224, SHA2_256, ...} */
+  uint8_t hash_type;
+
+  uint8_t reserved_4;
+
+  /* struct image_region array size. */
+  uint8_t region_count;
+  uint8_t reserved_1;
+  uint16_t reserved_2;
+  /* The sum of the image_region.region_size fields must add up. */
+  uint32_t image_size;
+  /* Authenticated opaque data exposed to system software. Must be a multiple
+   * of 4 to maintain alignment. Does not include the blob struct magic.
+   */
+  uint32_t blob_size;
+  /* The list is strictly ordered by region_offset.
+   * Must exhaustively describe the image.
+   */
+  struct image_region image_regions[];
+} __attribute__((__packed__));
+
+struct payload_version {
+  uint32_t major;
+  uint32_t minor;
+  uint32_t point;
+  uint32_t subpoint;
+};
+
+struct payload_info {
+  char image_name[32];
+  uint32_t image_family;
+  struct payload_version image_version;
+  uint8_t image_type;
+  uint8_t image_hash[HASH_SHA256_BYTES];
+};
+
+// Returns a pointer to a valid image_descriptor if found inside the image,
+// otherwise returns NULL
+const struct image_descriptor* libhoth_find_image_descriptor(const uint8_t* image,
+                                                       size_t len);
+bool libhoth_payload_info(const uint8_t* image, size_t len,
+                          struct payload_info* payload_info);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/protocol/payload_info_test.cc
+++ b/protocol/payload_info_test.cc
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protocol/payload_info.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+
+#include "payload_info.h"
+
+constexpr char kTestData[] = "protocol/test/test_payload.bin";
+constexpr char kTestHash[] =
+    "50316da1d3b006ff87989aa8bcd48a33ecc4bfe2114ded138ee594f6097d58b3";
+
+TEST(PayloadInfotest, payload_info) {
+  int fd = open(kTestData, O_RDONLY, 0);
+  ASSERT_NE(fd, -1);
+
+  struct stat statbuf;
+  ASSERT_EQ(fstat(fd, &statbuf), 0);
+
+  uint8_t *image = reinterpret_cast<uint8_t *>(
+      mmap(NULL, statbuf.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0));
+  ASSERT_NE(image, nullptr);
+
+  const struct image_descriptor *descr =
+      libhoth_find_image_descriptor(image, statbuf.st_size);
+
+  ASSERT_NE(descr, nullptr);
+
+  struct payload_info info;
+  EXPECT_TRUE(libhoth_payload_info(image, statbuf.st_size, &info));
+
+  EXPECT_STREQ(info.image_name, "test layout");
+  EXPECT_EQ(info.image_family, 2);
+
+  EXPECT_EQ(info.image_version.major, 1);
+  EXPECT_EQ(info.image_version.minor, 0);
+  EXPECT_EQ(info.image_version.point, 0);
+  EXPECT_EQ(info.image_version.subpoint, 0);
+
+  EXPECT_EQ(info.image_type, 0);
+
+  std::stringstream stream;
+  stream << std::hex;
+  for (const auto c : info.image_hash) {
+    stream << std::setw(2) << std::setfill('0') << (int)c;
+  }
+
+  EXPECT_EQ(kTestHash, stream.str());
+
+  // Clobber the magic
+  const_cast<image_descriptor *>(descr)->descriptor_magic += 1;
+
+  EXPECT_FALSE(libhoth_payload_info(image, statbuf.st_size, &info));
+
+  (void)munmap(image, statbuf.st_size);
+}
+
+TEST(PayloadInfotest, descriptor_clipping) {
+  int fd = open(kTestData, O_RDONLY, 0);
+  ASSERT_NE(fd, -1);
+
+  struct stat statbuf;
+  ASSERT_EQ(fstat(fd, &statbuf), 0);
+
+  uint8_t *image = reinterpret_cast<uint8_t *>(
+      mmap(NULL, statbuf.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0));
+  ASSERT_NE(image, nullptr);
+
+  struct image_descriptor *descr = const_cast<image_descriptor *>(
+      libhoth_find_image_descriptor(image, statbuf.st_size));
+  ASSERT_NE(descr, nullptr);
+
+  ASSERT_EQ(descr->descriptor_area_size, 2 * TITAN_IMAGE_DESCRIPTOR_ALIGNMENT);
+
+  void *end_of_image = image + statbuf.st_size - descr->descriptor_area_size;
+
+  // Move the descriptor to the very end, so that the regions just barely fits
+  // into the last 2 64K slots at the end
+  std::memcpy(end_of_image, descr, sizeof(image_descriptor));
+  descr->descriptor_magic += 1;  // Clobber previous image descriptor
+
+  descr = const_cast<image_descriptor*>(libhoth_find_image_descriptor(image, statbuf.st_size));
+  ASSERT_NE(descr, nullptr);
+
+  // Move the points to the last 64K
+  // Putting the descriptor in here should fail because it extends
+  // beyond the end of the payload
+  end_of_image = (uint8_t *)end_of_image + (1 << 16);
+
+  std::memcpy(end_of_image, descr, sizeof(image_descriptor));
+  descr->descriptor_magic += 1;  // Clobber previous image descriptor
+
+  EXPECT_EQ(libhoth_find_image_descriptor(image, statbuf.st_size), nullptr);
+
+  (void)munmap(image, statbuf.st_size);
+}

--- a/protocol/payload_update.c
+++ b/protocol/payload_update.c
@@ -18,21 +18,7 @@
 #include <string.h>
 
 #include "host_cmd.h"
-
-const int64_t TITAN_IMAGE_DESCRIPTOR_MAGIC = 0x5F435344474D495F;
-const int64_t TITAN_IMAGE_DESCRIPTOR_ALIGNMENT = 1 << 16;
-
-static bool find_image_descriptor(uint8_t* image, size_t len) {
-  for (size_t offset = 0; offset + sizeof(int64_t) - 1 < len;
-       offset += TITAN_IMAGE_DESCRIPTOR_ALIGNMENT) {
-    int64_t magic_candidate;
-    memcpy(&magic_candidate, image + offset, sizeof(int64_t));
-    if (magic_candidate == TITAN_IMAGE_DESCRIPTOR_MAGIC) {
-      return true;
-    }
-  }
-  return false;
-}
+#include "payload_info.h"
 
 static int send_payload_update_request_with_command(struct libhoth_device* dev,
                                                     uint8_t command) {
@@ -53,7 +39,7 @@ static int send_payload_update_request_with_command(struct libhoth_device* dev,
 
 enum payload_update_err libhoth_payload_update(struct libhoth_device* dev,
                                                uint8_t* image, size_t size) {
-  if (!find_image_descriptor(image, size)) {
+  if (libhoth_find_image_descriptor(image, size) == NULL) {
     return PAYLOAD_UPDATE_BAD_IMG;
   }
 

--- a/protocol/progress.c
+++ b/protocol/progress.c
@@ -52,7 +52,7 @@ struct stderr_progress {
 };
 
 static void libhoth_progress_stderr_func(void* param, uint64_t numerator,
-                                       uint64_t denominator) {
+                                         uint64_t denominator) {
   struct stderr_progress* self = (struct stderr_progress*)param;
   if (isatty(STDERR_FILENO)) {
     uint64_t duration_ms =
@@ -74,7 +74,7 @@ static void libhoth_progress_stderr_func(void* param, uint64_t numerator,
 }
 
 void libhoth_progress_stderr_init(struct libhoth_progress_stderr* progress,
-                                const char* action_title) {
+                                  const char* action_title) {
   progress->progress.param = progress;
   progress->progress.func = libhoth_progress_stderr_func;
   progress->start_time = ts_now();

--- a/protocol/progress.h
+++ b/protocol/progress.h
@@ -34,11 +34,10 @@ struct libhoth_progress_stderr {
 };
 
 void libhoth_progress_stderr_init(struct libhoth_progress_stderr* progress,
-                                const char* action_title);
-
+                                  const char* action_title);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif


### PR DESCRIPTION
Add payload inspection to libHoth and an option to htool:

htool payload info protocol/test/test_payload.bin 
Payload Info:
  name: test layout                     
  family: 2
  version: 1.0.0.0
  type: 0
  hash: 50316da1d3b06ff87989aa8bcd48a33ecc4bfe2114ded138ee594f697d58b3
