### PR TITLE
Fix D-Bus builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           bazel build --copt="-Werror" ...
 
+      - name: Build htool with D-Bus
+        run: |
+          bazel build --define dbus_backend=true  //examples:htool
+
       - name: Bazel tests
         run: |
           bazel test ...

--- a/examples/htool_dbus.c
+++ b/examples/htool_dbus.c
@@ -16,7 +16,7 @@
 
 #ifdef DBUS_BACKEND
 
-#include "../libhoth_dbus.h"
+#include "transports/libhoth_dbus.h"
 #include "htool_cmd.h"
 
 struct libhoth_device* htool_libhoth_dbus_device(void) {


### PR DESCRIPTION
Htool with D-Bus support currently does not build after the refactor.  Fixed and added a CI check to ensure it builds.