### PR TITLE
Update host command interface to include libhoth name

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -193,7 +193,7 @@ static int command_authz_host_command_build(
   }
 
   struct ec_authorized_command_get_nonce_response nonce_resp;
-  status = hostcmd_exec(
+  status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_GET_AUTHZ_COMMAND_NONCE,
       /*version=*/0, NULL, 0, &nonce_resp, sizeof(nonce_resp), NULL);
   if (status != 0) {
@@ -225,7 +225,7 @@ static int command_authz_host_command_send(const struct htool_invocation* inv) {
     return -1;
   }
 
-  status = hostcmd_exec(
+  status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_AUTHZ_COMMAND,
       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
   if (status != 0) {
@@ -426,7 +426,7 @@ static int do_target_reset(uint32_t reset_option) {
       .target_id = RESET_TARGET_ID_RSTCTRL0,
       .reset_option = reset_option,
   };
-  return hostcmd_exec(dev,
+  return libhoth_hostcmd_exec(dev,
                       EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_RESET_TARGET,
                       0, &req, sizeof(req), NULL, 0, NULL);
 }
@@ -488,7 +488,7 @@ static int command_flash_spi_info(const struct htool_invocation* inv) {
     return -1;
   }
   struct ec_response_flash_spi_info response;
-  int status = hostcmd_exec(dev, EC_CMD_FLASH_SPI_INFO, /*version=*/0, NULL, 0,
+  int status = libhoth_hostcmd_exec(dev, EC_CMD_FLASH_SPI_INFO, /*version=*/0, NULL, 0,
                             &response, sizeof(response), NULL);
   if (status) {
     return -1;
@@ -517,7 +517,7 @@ static int command_arm_coordinated_reset(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_ARM_COORDINATED_RESET,
       /*version=*/0, NULL, 0, NULL, 0, NULL);
 }
@@ -528,7 +528,7 @@ static int command_passthrough_disable(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SPS_PASSTHROUGH_DISABLE,
       /*version=*/0, NULL, 0, NULL, 0, NULL);
 }
@@ -539,7 +539,7 @@ static int command_passthrough_enable(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SPS_PASSTHROUGH_ENABLE,
       /*version=*/0, NULL, 0, NULL, 0, NULL);
 }
@@ -560,7 +560,7 @@ static int command_srtm(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return hostcmd_exec(dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SRTM,
+  return libhoth_hostcmd_exec(dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SRTM,
                       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
 }
 

--- a/examples/htool_console.c
+++ b/examples/htool_console.c
@@ -44,7 +44,7 @@ static int get_channel_status(struct libhoth_device *dev,
   };
   struct ec_channel_status_response resp;
 
-  int status = hostcmd_exec(
+  int status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHANNEL_STATUS,
       /*version=*/0, &req, sizeof(req), &resp, sizeof(resp), NULL);
   if (status) {
@@ -99,7 +99,7 @@ static int read_console(struct libhoth_device *dev,
                  "unexpected layout");
 
   size_t response_size = 0;
-  int status = hostcmd_exec(
+  int status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHANNEL_READ,
       /*version=*/0, &req, sizeof(req), &resp, sizeof(resp), &response_size);
   if (status != 0) {
@@ -215,7 +215,7 @@ static int write_console(struct libhoth_device *dev,
   req.req.flags |=
       flags.uart_break ? EC_CHANNEL_WRITE_REQUEST_FLAG_SEND_BREAK : 0;
 
-  int status = hostcmd_exec(
+  int status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHANNEL_WRITE,
       /*version=*/1, &req, sizeof(req.req) + numWrite, NULL, 0, NULL);
 
@@ -238,7 +238,7 @@ static int get_uart_config(struct libhoth_device *dev,
   struct ec_channel_uart_config_get_req req = {
       .channel_id = opts->channel_id,
   };
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHANNEL_UART_CONFIG_GET,
       /*version=*/0, &req, sizeof(req), resp, sizeof(*resp), NULL);
 }
@@ -249,7 +249,7 @@ static int set_uart_config(struct libhoth_device *dev,
       .channel_id = opts->channel_id,
       .config = *config,
   };
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHANNEL_UART_CONFIG_SET,
       /*version=*/0, &req, sizeof(req), NULL, 0, NULL);
 }
@@ -372,7 +372,7 @@ int htool_console_run(struct libhoth_device *dev,
 
 int htool_console_snapshot_legacy(struct libhoth_device *dev) {
   size_t response_bytes_written;
-  int status = hostcmd_exec(dev, EC_CMD_CONSOLE_REQUEST, 0, NULL, 0, NULL, 0,
+  int status = libhoth_hostcmd_exec(dev, EC_CMD_CONSOLE_REQUEST, 0, NULL, 0, NULL, 0,
                             &response_bytes_written);
   if (status != LIBHOTH_OK) {
     fprintf(stderr, "EC_CMD_CONSOLE_REQUEST status: %d\n", status);
@@ -384,7 +384,7 @@ int htool_console_snapshot_legacy(struct libhoth_device *dev) {
       MAILBOX_SIZE - sizeof(struct ec_host_response);
   while (true) {
     char buf[MAILBOX_SIZE];
-    status = hostcmd_exec(dev, EC_CMD_CONSOLE_READ, 0, &read_request,
+    status = libhoth_hostcmd_exec(dev, EC_CMD_CONSOLE_READ, 0, &read_request,
                           sizeof(read_request), buf, max_bytes_per_read,
                           &response_bytes_written);
     if (status != LIBHOTH_OK) {

--- a/examples/htool_jtag.c
+++ b/examples/htool_jtag.c
@@ -53,7 +53,7 @@ static int jtag_read_idcode(struct libhoth_device *dev,
 
   struct ec_response_jtag_read_idcode_operation response;
   size_t response_length = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), &response, sizeof(response),
       &response_length);
@@ -159,7 +159,7 @@ static int jtag_test_bypass(struct libhoth_device *dev,
 
   struct ec_response_jtag_test_bypass_operation response;
   size_t response_len = 0;
-  ret = hostcmd_exec(
+  ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), &response, sizeof(response),
       &response_len);
@@ -215,7 +215,7 @@ static int jtag_program_and_verify_pld(struct libhoth_device *dev,
   };
 
   size_t response_length = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);
@@ -259,7 +259,7 @@ static int jtag_verify_pld(struct libhoth_device *dev,
   };
 
   size_t response_length = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);

--- a/examples/htool_raw_host_command.c
+++ b/examples/htool_raw_host_command.c
@@ -111,7 +111,7 @@ int command_raw_host_command(const struct htool_invocation* inv) {
       return rv;
     }
 
-    uint8_t checksum = calculate_ec_command_checksum(&req, sizeof(req),
+    uint8_t checksum = libhoth_calculate_checksum(&req, sizeof(req),
                                                      req_payload, req.data_len);
     if (checksum != 0) {
       fprintf(stderr, "bad request checksum; expected 0, got %d\n", checksum);
@@ -126,7 +126,7 @@ int command_raw_host_command(const struct htool_invocation* inv) {
     uint8_t resp_payload[RESP_BUF_LEN] = {0};
 
     size_t actual_resp_size = 0;
-    rv = hostcmd_exec(dev, req.command, req.command_version, req_payload,
+    rv = libhoth_hostcmd_exec(dev, req.command, req.command_version, req_payload,
                       req.data_len, resp_payload, RESP_BUF_LEN,
                       &actual_resp_size);
     if (rv && rv < HTOOL_ERROR_HOST_COMMAND_START) {
@@ -137,7 +137,7 @@ int command_raw_host_command(const struct htool_invocation* inv) {
     }
 
     resp.data_len = actual_resp_size;
-    resp.checksum = calculate_ec_command_checksum(
+    resp.checksum = libhoth_calculate_checksum(
         &resp, sizeof(resp), resp_payload, actual_resp_size);
 
     rv = fd_write_exact(STDOUT_FILENO, &resp, sizeof(resp));

--- a/examples/htool_target_control.c
+++ b/examples/htool_target_control.c
@@ -39,7 +39,7 @@ int target_control_perform_action(
   };
 
   size_t response_length = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_TARGET_CONTROL,
       /*version=*/0, &request, sizeof(request), response, sizeof(*response),
       &response_length);

--- a/protocol/authz_record.c
+++ b/protocol/authz_record.c
@@ -24,7 +24,7 @@ int libhoth_authz_record_erase(struct libhoth_device* dev) {
       .index = 0,
       .erase = 1,
   };
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
 }
@@ -32,7 +32,7 @@ int libhoth_authz_record_erase(struct libhoth_device* dev) {
 int libhoth_authz_record_read(struct libhoth_device* dev,
                               struct ec_authz_record_get_response* resp) {
   struct ec_authz_record_get_request request = {.index = 0};
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_GET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), resp, sizeof(*resp), NULL);
 }
@@ -57,7 +57,7 @@ int libhoth_authz_record_build(struct libhoth_device* dev,
   record->dev_id_1 = (chipinfo_resp.hardware_identity >> 32);
 
   struct ec_authz_record_get_nonce_response nonce_resp;
-  status = hostcmd_exec(
+  status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_GET_AUTHZ_RECORD_NONCE,
       /*version=*/0, NULL, 0, &nonce_resp, sizeof(nonce_resp), NULL);
   if (status != 0) {
@@ -98,7 +98,7 @@ int libhoth_authz_record_set(struct libhoth_device* dev,
 
   memcpy(&request.record, record, sizeof(struct authorization_record));
 
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
 }

--- a/protocol/chipinfo.c
+++ b/protocol/chipinfo.c
@@ -18,7 +18,7 @@
 
 int libhoth_chipinfo(struct libhoth_device* dev,
                      struct ec_response_chip_info* chipinfo) {
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_CHIP_INFO,
       /*version=*/0, NULL, 0, chipinfo, sizeof(*chipinfo), NULL);
 }

--- a/protocol/host_cmd.c
+++ b/protocol/host_cmd.c
@@ -56,7 +56,7 @@ void hex_dump(FILE* out, const void* buffer, size_t size) {
   }
 }
 
-uint8_t calculate_ec_command_checksum(const void* header, size_t header_size,
+uint8_t libhoth_calculate_checksum(const void* header, size_t header_size,
                                       const void* data, size_t data_size) {
   size_t i;
   uint8_t sum = 0;
@@ -100,7 +100,7 @@ static int populate_ec_request_header(uint16_t command, uint8_t command_version,
   request_header->reserved = 0;
   request_header->data_len = (uint16_t)request_size;
   // Note that we've set `checksum` to zero earlier, so this is deterministic.
-  request_header->checksum = calculate_ec_command_checksum(
+  request_header->checksum = libhoth_calculate_checksum(
       request_header, sizeof(*request_header), request, request_size);
 
   return 0;
@@ -137,7 +137,7 @@ static int validate_ec_response_header(
   }
 
   response_checksum =
-      calculate_ec_command_checksum(response_header, sizeof(*response_header),
+      libhoth_calculate_checksum(response_header, sizeof(*response_header),
                                     response, response_header->data_len);
 
   // Since this checksum includes the `checksum` field in `response_header`, it
@@ -154,7 +154,7 @@ static int validate_ec_response_header(
   return 0;
 }
 
-int hostcmd_exec(struct libhoth_device* dev, uint16_t command, uint8_t version,
+int libhoth_hostcmd_exec(struct libhoth_device* dev, uint16_t command, uint8_t version,
                  const void* req_payload, size_t req_payload_size,
                  void* resp_buf, size_t resp_buf_size, size_t* out_resp_size) {
   struct {

--- a/protocol/host_cmd.h
+++ b/protocol/host_cmd.h
@@ -99,12 +99,13 @@ struct ec_host_response {
   uint16_t reserved;
 } __ec_align4;
 
-int hostcmd_exec(struct libhoth_device* dev, uint16_t command, uint8_t version,
-                 const void* req_payload, size_t req_payload_size,
-                 void* resp_buf, size_t resp_buf_size, size_t* out_resp_size);
+int libhoth_hostcmd_exec(struct libhoth_device* dev, uint16_t command,
+                         uint8_t version, const void* req_payload,
+                         size_t req_payload_size, void* resp_buf,
+                         size_t resp_buf_size, size_t* out_resp_size);
 
-uint8_t calculate_ec_command_checksum(const void* header, size_t header_size,
-                                      const void* data, size_t data_size);
+uint8_t libhoth_calculate_checksum(const void* header, size_t header_size,
+                                   const void* data, size_t data_size);
 
 void hex_dump(FILE* out, const void* buffer, size_t size);
 

--- a/protocol/i2c.c
+++ b/protocol/i2c.c
@@ -23,7 +23,7 @@ int libhoth_i2c_detect(struct libhoth_device* dev,
                        struct ec_response_i2c_detect* resp) {
   size_t rLen = 0;
   int ret =
-      hostcmd_exec(dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_I2C_DETECT,
+      libhoth_hostcmd_exec(dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_I2C_DETECT,
                    0, req, sizeof(*req), resp, sizeof(*resp), &rLen);
   if (ret != 0) {
     fprintf(stderr, "HOTH_I2C_DETECT error code: %d\n", ret);
@@ -67,7 +67,7 @@ int libhoth_i2c_transfer(struct libhoth_device* dev,
                          struct ec_request_i2c_transfer* req,
                          struct ec_response_i2c_transfer* resp) {
   size_t rLen = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_I2C_TRANSFER, 0, req,
       sizeof(*req), resp, sizeof(*resp), &rLen);
   if (ret != 0) {

--- a/protocol/panic.c
+++ b/protocol/panic.c
@@ -199,7 +199,7 @@ int libhoth_get_panic(struct libhoth_device* dev,
     };
 
     int ret =
-        hostcmd_exec(dev, cmd, 0, &req, sizeof(req), dest, chunk_size, &rlen);
+        libhoth_hostcmd_exec(dev, cmd, 0, &req, sizeof(req), dest, chunk_size, &rlen);
 
     if (ret) {
       return -1;
@@ -222,7 +222,7 @@ int libhoth_clear_persistent_panic_info(struct libhoth_device* dev) {
   const uint16_t cmd =
       EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_PERSISTENT_PANIC_INFO;
 
-  if (hostcmd_exec(dev, cmd, 0, &req, sizeof(req), NULL, 0, &rlen)) {
+  if (libhoth_hostcmd_exec(dev, cmd, 0, &req, sizeof(req), NULL, 0, &rlen)) {
     return -1;
   }
 

--- a/protocol/payload_status.c
+++ b/protocol/payload_status.c
@@ -21,7 +21,7 @@
 int libhoth_payload_status(struct libhoth_device* dev,
                            struct payload_status* payload_status) {
   size_t rlen = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_PAYLOAD_STATUS, 0, NULL,
       0, payload_status, sizeof(*payload_status), &rlen);
 

--- a/protocol/payload_update.c
+++ b/protocol/payload_update.c
@@ -27,7 +27,7 @@ static int send_payload_update_request_with_command(struct libhoth_device* dev,
   request.offset = 0;
   request.len = 0;
 
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
       &request, sizeof(request), NULL, 0, NULL);
   if (ret != 0) {
@@ -81,7 +81,7 @@ enum payload_update_err libhoth_payload_update(struct libhoth_device* dev,
     memcpy(buffer, &request, sizeof(request));
     memcpy(buffer + sizeof(request), image + offset, chunk_size);
 
-    int ret = hostcmd_exec(
+    int ret = libhoth_hostcmd_exec(
         dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
         buffer, sizeof(request) + chunk_size, NULL, 0, NULL);
     if (ret != 0) {
@@ -109,7 +109,7 @@ int libhoth_payload_update_getstatus(
   request.len = 0;
 
   size_t rlen = 0;
-  int ret = hostcmd_exec(
+  int ret = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
       &request, sizeof(request), update_status, sizeof(*update_status), &rlen);
 

--- a/protocol/reboot.c
+++ b/protocol/reboot.c
@@ -20,6 +20,6 @@ int libhoth_reboot(struct libhoth_device* dev) {
   struct ec_params_reboot_ec req = {
       .cmd = EC_REBOOT_COLD,
   };
-  return hostcmd_exec(dev, EC_CMD_REBOOT_EC, 0, &req, sizeof(req), NULL, 0,
+  return libhoth_hostcmd_exec(dev, EC_CMD_REBOOT_EC, 0, &req, sizeof(req), NULL, 0,
                       NULL);
 }

--- a/protocol/rot_firmware_version.c
+++ b/protocol/rot_firmware_version.c
@@ -16,7 +16,7 @@
 
 int libhoth_get_rot_fw_version(struct libhoth_device* dev,
                                struct ec_response_get_version* ver) {
-  return hostcmd_exec(dev, EC_CMD_GET_VERSION, /*version=*/0,
+  return libhoth_hostcmd_exec(dev, EC_CMD_GET_VERSION, /*version=*/0,
                       /*req_payload=*/NULL, /*req_payload_size=*/0, ver,
                       sizeof(*ver), /*out_resp_size=*/NULL);
 }

--- a/protocol/spi_proxy.c
+++ b/protocol/spi_proxy.c
@@ -64,7 +64,7 @@ static int spi_operation_execute(struct spi_operation* op,
   size_t response_len;
 
   // hexdump(op->buf, op->pos);
-  int status = hostcmd_exec(
+  int status = libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_SPI_OPERATION,
       /*version=*/0, op->buf, op->pos, response_buf, sizeof(response_buf),
       &response_len);

--- a/protocol/statistics.c
+++ b/protocol/statistics.c
@@ -19,7 +19,7 @@
 int libhoth_get_statistics(struct libhoth_device* dev,
                            struct ec_response_statistics* stats) {
   size_t rlen = 0;
-  return hostcmd_exec(
+  return libhoth_hostcmd_exec(
       dev, EC_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HOTH_GET_STATISTICS, 0, NULL,
       0, stats, sizeof(*stats), &rlen);
 }

--- a/protocol/test/libhoth_device_mock.h
+++ b/protocol/test/libhoth_device_mock.h
@@ -65,7 +65,7 @@ ACTION_P(CopyResp, response, resp_size) {
 
   std::memcpy(resp.payload_buf, response, resp_size);
 
-  resp.hdr.checksum = calculate_ec_command_checksum(
+  resp.hdr.checksum = libhoth_calculate_checksum(
       &resp.hdr, sizeof(resp.hdr), &resp.payload_buf, resp_size);
 
   std::memcpy(arg1, &resp, full_resp_size);


### PR DESCRIPTION
This is a purely cosmetic change to rename the host command interface to prepend 'libhoth_' to avoid clashes with other symbols