### PR TITLE
Fixing the meson build library and header file install

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -6,7 +6,7 @@ git_version_h = vcs_tag(
 )
 
 incdir = include_directories('..')
-link_with = [libhoth_transport, libhoth_protocol, ]
+link_with = [libhoth.get_static_lib()]
 c_args = []
 
 if get_option('dbus_backend')

--- a/meson.build
+++ b/meson.build
@@ -3,13 +3,17 @@ project('libhoth', 'c', 'cpp', license: 'Apache-2.0', version: '0.0.0')
 subdir('transports')
 subdir('protocol')
 
-install_headers('transports/libhoth_device.h')
-install_headers('transports/libhoth_spi.h')
-install_headers('transports/libhoth_usb.h')
-install_headers('transports/libhoth_usb_device.h')
 
-libhoth = library('hoth', [], link_with: [libhoth_transport, libhoth_protocol], dependencies: [libusb], \
-    version: meson.project_version())
+libhoth = both_libraries('hoth',
+    [],
+    objects: [
+        libhoth_transport.extract_all_objects(recursive:false),
+        libhoth_protocol.extract_all_objects(recursive:false),
+    ],
+    dependencies: [libusb],
+    version: meson.project_version(),
+    install: true
+)
 
 pkg = import('pkgconfig')
 pkg.generate([libhoth], name: 'libhoth', description: 'Hoth interface library')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -19,4 +19,18 @@ protocol_srcs = [
 
 incdir = include_directories('..')
 
-libhoth_protocol = library('hoth_protocols', protocol_srcs, include_directories: incdir, link_with: [libhoth_transport])
+libhoth_protocol = static_library(
+  'hoth_protocols',
+  protocol_srcs,
+  include_directories: incdir,
+  link_with: [libhoth_transport]
+)
+
+libhoth_protocol_headers = []
+foreach s : protocol_srcs
+    base_name = s.split('/')[-1]
+    header_name = base_name.replace('.c', '.h')
+    libhoth_protocol_headers += header_name
+endforeach
+
+install_headers(libhoth_protocol_headers, subdir:'protocol')

--- a/transports/meson.build
+++ b/transports/meson.build
@@ -10,6 +10,27 @@ transport_srcs = [
 incdir = include_directories('..')
 libusb = dependency('libusb-1.0')
 libsystemd = dependency('libsystemd')
-libhoth_dbus = static_library('hoth_dbus', 'libhoth_dbus.c', include_directories: incdir, dependencies: [libsystemd])
+
+if get_option('dbus_backend')
+  libhoth_dbus = static_library(
+    'hoth_dbus',
+    'libhoth_dbus.c',
+    include_directories: incdir,
+    dependencies: [libsystemd],
+    install:true
+  )
+  install_headers(['libhoth_dbus.h'], subdir:'transports')
+endif
+
 libhoth_transport = static_library('hoth_transports', transport_srcs, include_directories: incdir, dependencies: [libusb])
+
+libhoth_transport_headers = [
+  'libhoth_device.h',
+  'libhoth_ec.h',
+  'libhoth_mtd.h',
+  'libhoth_spi.h',
+  'libhoth_usb.h',
+  'libhoth_usb_device.h',
+]
+install_headers(libhoth_transport_headers, subdir:'transports')
 


### PR DESCRIPTION
change the new refactored libhoth_protocol as internal static library and export it together with libhoth_transport as libhoth

build and install both static and dynamic library of libhoth

build htool example application static link with libhoth to make it an autonomous green tool.

export header files in protocol and transports

export header file and libhoth_dbus.a when dbus_backend enabled

Tested
```
oot@my-ut:latest:/opt/bmc/libhoth/builddir# ninja install
[1/2] Installing files.
Installing libhoth.so.0.0.0 to /usr/local/lib/x86_64-linux-gnu
Installing libhoth.a to /usr/local/lib/x86_64-linux-gnu
Installing examples/htool to /usr/local/bin
Installing /opt/bmc/libhoth/transports/libhoth_device.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_ec.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_mtd.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_spi.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_usb.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_usb_device.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/protocol/host_cmd.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/rot_firmware_version.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_status.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/panic.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_update.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/statistics.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/reboot.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/chipinfo.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/i2c.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/authz_record.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/progress.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/spi_proxy.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_info.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/controlled_storage.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/jtag.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/hello.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/builddir/meson-private/libhoth.pc to /usr/local/lib/x86_64-linux-gnu/pkgconfig
Installing symlink pointing to libhoth.so.0.0.0 to /usr/local/lib/x86_64-linux-gnu/libhoth.so.0
Installing symlink pointing to libhoth.so.0 to /usr/local/lib/x86_64-linux-gnu/libhoth.so
```

dbus_end enabled
```
root@my-ut:latest:/opt/bmc/libhoth# meson setup --reconfig builddbus/
...
  User defined options
    dbus_backend: true
...
root@my-ut:latest:/opt/bmc/libhoth/builddbus# ninja install
[1/2] Installing files.
Installing transports/libhoth_dbus.a to /usr/local/lib/x86_64-linux-gnu
Installing libhoth.so.0.0.0 to /usr/local/lib/x86_64-linux-gnu
Installing libhoth.a to /usr/local/lib/x86_64-linux-gnu
Installing examples/htool to /usr/local/bin
Installing /opt/bmc/libhoth/transports/libhoth_dbus.h to /usr/local/include/transports
...
```