### PR TITLE
Meson build: make refactoring backward compatible

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('libhoth', 'c', 'cpp', license: 'Apache-2.0', version: '0.0.0')
 
+header_subdirs = []
 subdir('transports')
 subdir('protocol')
 
@@ -16,6 +17,10 @@ libhoth = both_libraries('hoth',
 )
 
 pkg = import('pkgconfig')
-pkg.generate([libhoth], name: 'libhoth', description: 'Hoth interface library')
+pkg.generate(
+    [libhoth],
+    name: 'libhoth',
+    description: 'Hoth interface library',
+    subdirs: header_subdirs)
 
 subdir('examples')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -35,3 +35,4 @@ foreach s : protocol_srcs
 endforeach
 
 install_headers(libhoth_protocol_headers, subdir:'protocol')
+header_subdirs += 'protocol'

--- a/transports/meson.build
+++ b/transports/meson.build
@@ -34,3 +34,9 @@ libhoth_transport_headers = [
 ]
 install_headers(libhoth_transport_headers, subdir:'transports')
 
+install_symlink(
+    'libhoth.h',
+    install_dir: get_option('includedir') / 'transports',
+    pointing_to: 'libhoth_device.h',
+)
+header_subdirs += 'transports'


### PR DESCRIPTION
leverage pkgconfig to add subdir in Cflag to avoid break current customer.
Also install the legacy libhoth.h as symlink to libhoth_device.h

Tested:
```
root@my-ut:latest:/opt/bmc/libhoth/buildut# ninja install
[1/2] Installing files.
Installing libhoth.so.0.0.0 to /usr/local/lib/x86_64-linux-gnu
Installing libhoth.a to /usr/local/lib/x86_64-linux-gnu
Installing examples/htool to /usr/local/bin
Installing /opt/bmc/libhoth/transports/libhoth_device.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_ec.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_mtd.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_spi.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_usb.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/transports/libhoth_usb_device.h to /usr/local/include/transports
Installing /opt/bmc/libhoth/protocol/host_cmd.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/rot_firmware_version.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_status.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/panic.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_update.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/statistics.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/reboot.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/chipinfo.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/i2c.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/authz_record.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/progress.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/spi_proxy.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/payload_info.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/controlled_storage.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/jtag.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/hello.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/protocol/key_rotation.h to /usr/local/include/protocol
Installing /opt/bmc/libhoth/buildut/meson-private/libhoth.pc to /usr/local/lib/x86_64-linux-gnu/pkgconfig
Installing symlink pointing to libhoth.so.0.0.0 to /usr/local/lib/x86_64-linux-gnu/libhoth.so.0
Installing symlink pointing to libhoth.so.0 to /usr/local/lib/x86_64-linux-gnu/libhoth.so
Installing symlink pointing to libhoth_device.h to /usr/local/include/transports/libhoth.h
```