### PR TITLE
Add argument to set SPI clock speed when using spidev transport to communicate with RoT

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -1370,6 +1370,9 @@ static const struct htool_param GLOBAL_FLAGS[] = {
      .desc = "If true, force spidev to send the request and receive the "
              "corresponding response with a single atomic ioctl.  This is "
              "required on some systems for correctness."},
+    {HTOOL_FLAG_VALUE, .name = "spidev_speed_hz", .default_value = "0",
+     .desc = "Clock speed (in Hz) to use when using spidev transport. Default "
+             "behavior (with input 0) is to not change the clock speed"},
     {HTOOL_FLAG_VALUE, .name = "mtddev_path", .default_value = "",
      .desc = "The full MTD path of the RoT mailbox; for example "
              "'/dev/mtd0'. If unspecified, will attempt to detect "

--- a/examples/htool_spi.c
+++ b/examples/htool_spi.c
@@ -34,11 +34,14 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
   const char* spidev_path_str;
   uint32_t mailbox_location;
   bool atomic;
+  uint32_t spidev_speed_hz;
   rv = htool_get_param_string(htool_global_flags(), "spidev_path",
                               &spidev_path_str) ||
        htool_get_param_u32(htool_global_flags(), "mailbox_location",
                            &mailbox_location) ||
-       htool_get_param_bool(htool_global_flags(), "spidev_atomic", &atomic);
+       htool_get_param_bool(htool_global_flags(), "spidev_atomic", &atomic) ||
+       htool_get_param_u32(htool_global_flags(), "spidev_speed_hz",
+                           &spidev_speed_hz);
   if (rv) {
     return NULL;
   }
@@ -52,6 +55,7 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
       .path = spidev_path_str,
       .mailbox = mailbox_location,
       .atomic = atomic,
+      .speed = spidev_speed_hz,
   };
   rv = libhoth_spi_open(&opts, &result);
   if (rv) {


### PR DESCRIPTION
Add argument to set SPI clock speed when using spidev transport to communicate with RoT
