### PR TITLE
Wait for SPI device to be not busy after page program when sending host command.

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -1373,6 +1373,14 @@ static const struct htool_param GLOBAL_FLAGS[] = {
     {HTOOL_FLAG_VALUE, .name = "spidev_speed_hz", .default_value = "0",
      .desc = "Clock speed (in Hz) to use when using spidev transport. Default "
              "behavior (with input 0) is to not change the clock speed"},
+    {HTOOL_FLAG_VALUE, .name = "spidev_device_busy_wait_timeout",
+     .default_value = "1000",
+     .desc = "Maximum duration (in microseconds) to wait when SPI device "
+             "indicates that it is busy"},
+    {HTOOL_FLAG_VALUE, .name = "spidev_device_busy_wait_check_interval",
+     .default_value = "100",
+     .desc = "Interval duration (in microseconds) to wait before checking SPI "
+             "device status again when it indicates that the device is busy"},
     {HTOOL_FLAG_VALUE, .name = "mtddev_path", .default_value = "",
      .desc = "The full MTD path of the RoT mailbox; for example "
              "'/dev/mtd0'. If unspecified, will attempt to detect "

--- a/examples/htool_spi.c
+++ b/examples/htool_spi.c
@@ -35,13 +35,21 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
   uint32_t mailbox_location;
   bool atomic;
   uint32_t spidev_speed_hz;
+  uint32_t spidev_device_busy_wait_timeout;
+  uint32_t spidev_device_busy_wait_check_interval;
   rv = htool_get_param_string(htool_global_flags(), "spidev_path",
                               &spidev_path_str) ||
        htool_get_param_u32(htool_global_flags(), "mailbox_location",
                            &mailbox_location) ||
        htool_get_param_bool(htool_global_flags(), "spidev_atomic", &atomic) ||
        htool_get_param_u32(htool_global_flags(), "spidev_speed_hz",
-                           &spidev_speed_hz);
+                           &spidev_speed_hz) ||
+       htool_get_param_u32(htool_global_flags(),
+                           "spidev_device_busy_wait_timeout",
+                           &spidev_device_busy_wait_timeout) ||
+       htool_get_param_u32(htool_global_flags(),
+                           "spidev_device_busy_wait_check_interval",
+                           &spidev_device_busy_wait_check_interval);
   if (rv) {
     return NULL;
   }
@@ -56,6 +64,8 @@ struct libhoth_device* htool_libhoth_spi_device(void) {
       .mailbox = mailbox_location,
       .atomic = atomic,
       .speed = spidev_speed_hz,
+      .device_busy_wait_timeout = spidev_device_busy_wait_timeout,
+      .device_busy_wait_check_interval = spidev_device_busy_wait_check_interval,
   };
   rv = libhoth_spi_open(&opts, &result);
   if (rv) {

--- a/transports/libhoth_spi.c
+++ b/transports/libhoth_spi.c
@@ -14,6 +14,7 @@
 
 #include "transports/libhoth_spi.h"
 
+#include <assert.h>
 #include <fcntl.h>
 #include <linux/spi/spidev.h>
 #include <linux/types.h>
@@ -23,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "transports/libhoth_device.h"
@@ -35,6 +37,8 @@ struct libhoth_spi_device {
 
   void* buffered_request;
   size_t buffered_request_size;
+  uint32_t device_busy_wait_timeout;
+  uint32_t device_busy_wait_check_interval;
 };
 
 int libhoth_spi_send_request(struct libhoth_device* dev, const void* request,
@@ -54,6 +58,10 @@ int libhoth_spi_send_and_receive_response(struct libhoth_device* dev,
 
 int libhoth_spi_close(struct libhoth_device* dev);
 
+enum {
+  SPI_NOR_DEVICE_STATUS_WIP_BIT = (1 << 0),
+};
+
 static int spi_nor_address(uint8_t* buf, uint32_t address,
                            bool address_mode_4b) {
   if (address_mode_4b) {
@@ -70,8 +78,69 @@ static int spi_nor_address(uint8_t* buf, uint32_t address,
   }
 }
 
+// Helper function to get current monotonic time in milliseconds
+static int get_monotonic_ms(uint64_t* time_ms) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    perror("clock_gettime failed");
+    return -1;
+  }
+  *time_ms = (((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000));
+  return 0;
+}
+
+static libhoth_status spi_nor_busy_wait(const int fd, uint32_t timeout_us,
+                                        uint32_t check_interval_us) {
+  uint8_t tx_buf[2];
+  uint8_t rx_buf[2];
+  static_assert(sizeof(tx_buf) == sizeof(rx_buf),
+                "Tx and Rx buffers must have the same size");
+
+  uint64_t start_time_ms;
+  if (get_monotonic_ms(&start_time_ms) != 0) {
+    return LIBHOTH_ERR_FAIL;
+  }
+  while (true) {
+    struct spi_ioc_transfer xfer = {0};
+    tx_buf[0] = 0x05;  // Read Status command
+    xfer.tx_buf = (uint64_t)tx_buf;
+    xfer.rx_buf = (uint64_t)rx_buf;
+    xfer.len = sizeof(rx_buf);
+    const int status = ioctl(fd, SPI_IOC_MESSAGE(1), xfer);
+    if (status < 0) {
+      return LIBHOTH_ERR_FAIL;
+    }
+
+    static_assert(sizeof(rx_buf) >= 2,
+                  "Rx buffer must have at least 2 entries");
+    const bool is_spi_device_busy = (rx_buf[1] & SPI_NOR_DEVICE_STATUS_WIP_BIT);
+    if (!is_spi_device_busy) {
+      return LIBHOTH_OK;
+    }
+
+    uint64_t current_time_ms;
+    if (get_monotonic_ms(&current_time_ms) != 0) {
+      return LIBHOTH_ERR_FAIL;
+    }
+    uint64_t time_elapsed_ms = 0;
+    if (current_time_ms < start_time_ms) {
+      // Wrap around
+      time_elapsed_ms = (UINT64_MAX - start_time_ms) + current_time_ms;
+    } else {
+      time_elapsed_ms = current_time_ms - start_time_ms;
+    }
+
+    if (time_elapsed_ms > (timeout_us / 1000)) {
+      return LIBHOTH_ERR_TIMEOUT;
+    }
+    usleep(check_interval_us);
+  }
+}
+
 static int spi_nor_write(int fd, bool address_mode_4b, unsigned int address,
-                         const void* data, size_t data_len) {
+                         const void* data, size_t data_len,
+                         uint32_t device_busy_wait_timeout,
+                         uint32_t device_busy_wait_check_interval) {
   if (fd < 0 || !data || !data_len) return LIBHOTH_ERR_INVALID_PARAMETER;
 
   uint8_t wp_buf[1] = {};
@@ -105,7 +174,9 @@ static int spi_nor_write(int fd, bool address_mode_4b, unsigned int address,
     return LIBHOTH_ERR_FAIL;
   }
 
-  return LIBHOTH_OK;
+  libhoth_status busy_wait_status = spi_nor_busy_wait(
+      fd, device_busy_wait_timeout, device_busy_wait_check_interval);
+  return busy_wait_status;
 }
 
 static int spi_nor_read(int fd, bool address_mode_4b, unsigned int address,
@@ -203,6 +274,9 @@ int libhoth_spi_open(const struct libhoth_spi_device_init_options* options,
   spi_dev->fd = fd;
   spi_dev->mailbox_address = options->mailbox;
   spi_dev->address_mode_4b = true;
+  spi_dev->device_busy_wait_timeout = options->device_busy_wait_timeout;
+  spi_dev->device_busy_wait_check_interval =
+      options->device_busy_wait_check_interval;
 
   if (options->atomic) {
     dev->send = libhoth_spi_buffer_request;
@@ -243,7 +317,9 @@ int libhoth_spi_send_request(struct libhoth_device* dev, const void* request,
       (struct libhoth_spi_device*)dev->user_ctx;
 
   return spi_nor_write(spi_dev->fd, spi_dev->address_mode_4b,
-                       spi_dev->mailbox_address, request, request_size);
+                       spi_dev->mailbox_address, request, request_size,
+                       spi_dev->device_busy_wait_timeout,
+                       spi_dev->device_busy_wait_check_interval);
 }
 
 int libhoth_spi_receive_response(struct libhoth_device* dev, void* response,

--- a/transports/libhoth_spi.h
+++ b/transports/libhoth_spi.h
@@ -16,6 +16,7 @@
 #define _LIBHOTH_LIBHOTH_SPI_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +33,8 @@ struct libhoth_spi_device_init_options {
   int mode;
   int speed;
   int atomic;
+  uint32_t device_busy_wait_timeout;
+  uint32_t device_busy_wait_check_interval;
 };
 
 // Note that the options struct only needs to to live for the duration of


### PR DESCRIPTION
Wait for SPI device to be not busy after page program when sending host command.

Add new arguments to specify:
- Maximum time to wait while SPI device is busy before failing the SPI write operation
- Duration of interval to use when checking whether the SPI device is busy or not in a loop
