### PR TITLE
Read data from host command response only when header indicates that there is some data.

### DIFF
--- a/transports/libhoth_spi.c
+++ b/transports/libhoth_spi.c
@@ -361,13 +361,15 @@ int libhoth_spi_receive_response(struct libhoth_device* dev, void* response,
     return LIBHOTH_ERR_RESPONSE_BUFFER_OVERFLOW;
   }
 
-  // Read remainder of data based on header length
-  uint8_t* const data_start = (uint8_t*)response + total_bytes;
-  status = spi_nor_read(spi_dev->fd, spi_dev->address_mode_4b,
-                        spi_dev->mailbox_address + total_bytes, data_start,
-                        host_response.data_len);
-  if (status != LIBHOTH_OK) {
-    return status;
+  if (host_response.data_len > 0) {
+    // Read remainder of data based on header length
+    uint8_t* const data_start = (uint8_t*)response + total_bytes;
+    status = spi_nor_read(spi_dev->fd, spi_dev->address_mode_4b,
+                          spi_dev->mailbox_address + total_bytes, data_start,
+                          host_response.data_len);
+    if (status != LIBHOTH_OK) {
+      return status;
+    }
   }
 
   if (actual_size) {


### PR DESCRIPTION
Read data from host command response only when header indicates that there is some data.

When running `console -s` over spidev interface, the host command header response for `HOTH_CMD_CONSOLE_REQUEST` command indicates that there is no data to read. `spi_nor_read` is called regardless of data size, and returns error since data size is 0. This causes the command line invocation to fail. To fix this, `spi_nor_read` will only be called if the host command response header indicates that there is some data to be read.
