### PR TITLE
Add sbs commands for SBS mux control

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -67,6 +67,8 @@ cc_binary(
         "htool_statistics.h",
         "htool_target_control.c",
         "htool_target_control.h",
+        "htool_sbs.c",
+        "htool_sbs.h",
         "htool_update_failure_reasons.h",
         "htool_usb.c",
         "htool_usb.h",

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -327,6 +327,16 @@ enum hoth_target_control_action {
   // Changes the status of the given function to "Enabled". Returns the previous
   // enabled/disabled status of the given function.
   HOTH_TARGET_CONTROL_ACTION_ENABLE = 2,
+
+  // Recommended to be used for `HOTH_TARGET_CONTROL_SBS_MUX` function
+  HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_TARGET_TO_SPI_FLASH_0 =
+      HOTH_TARGET_CONTROL_ACTION_DISABLE,
+  HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_TARGET_TO_SPI_FLASH_1 =
+      HOTH_TARGET_CONTROL_ACTION_ENABLE,
+  HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_FLASH_TO_ROT =
+      HOTH_TARGET_CONTROL_ACTION_DISABLE,
+  HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_FLASH_TO_TARGET =
+      HOTH_TARGET_CONTROL_ACTION_ENABLE,
 };
 
 enum hoth_target_control_function {
@@ -339,6 +349,7 @@ enum hoth_target_control_function {
   // Allow checking whether external USB host is connected to system in which
   // RoT is present
   HOTH_TARGET_DETECT_EXTERNAL_USB_HOST_PRESENCE = 4,
+  HOTH_TARGET_CONTROL_SBS_MUX = 5,
   HOTH_TARGET_CONTROL_FUNCTION_MAX,
 };
 
@@ -351,6 +362,12 @@ enum hoth_target_control_status {
   HOTH_TARGET_EXTERNAL_USB_HOST_NOT_PRESENT =
       HOTH_TARGET_CONTROL_STATUS_DISABLED,
   HOTH_TARGET_EXTERNAL_USB_HOST_PRESENT = HOTH_TARGET_CONTROL_STATUS_ENABLED,
+
+  // Recommended to be used for `HOTH_TARGET_CONTROL_SBS_MUX` function
+  HOTH_TARGET_CONTROL_SBS_MUX_TARGET_CONNECTED_TO_SPI_FLASH_0 =
+      HOTH_TARGET_CONTROL_STATUS_DISABLED,
+  HOTH_TARGET_CONTROL_SBS_MUX_TARGET_CONNECTED_TO_SPI_FLASH_1 =
+      HOTH_TARGET_CONTROL_STATUS_ENABLED,
 };
 
 struct hoth_request_target_control {

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -45,6 +45,7 @@
 #include "htool_srtm.h"
 #include "htool_statistics.h"
 #include "htool_target_control.h"
+#include "htool_sbs.h"
 #include "htool_usb.h"
 #include "protocol/authz_record.h"
 #include "protocol/chipinfo.h"
@@ -1020,6 +1021,40 @@ static const struct htool_cmd CMDS[] = {
                          "hexidecimal string of 128 bytes or less."},
                 {}},
         .func = command_srtm,
+    },
+    {
+        .verbs = (const char*[]){"sbs", SBS_GET_CMD_STR, NULL},
+        .desc = "Get status of SBS mux select",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_sbs_run,
+    },
+    {
+        .verbs = (const char*[]){"sbs", SBS_CONNECT_FLASH_TO_ROT_CMD_STR, NULL},
+        .desc = "Set mux to connect flash to RoT (SBS Single)",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_sbs_run,
+    },
+    {
+        .verbs = (const char*[]){"sbs", SBS_CONNECT_FLASH_TO_TARGET_CMD_STR, NULL},
+        .desc = "Set mux to connect flash to target (SBS Single)",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_sbs_run,
+    },
+    {
+        .verbs = (const char*[]){"sbs",
+                                 SBS_CONNECT_TARGET_TO_SPI_FLASH_0_CMD_STR,
+                                 NULL},
+        .desc = "Set mux select pin to connect target to spi flash 1 (SBS Dual)",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_sbs_run,
+    },
+    {
+        .verbs = (const char*[]){"sbs",
+                                 SBS_CONNECT_TARGET_TO_SPI_FLASH_1_CMD_STR,
+                                 NULL},
+        .desc = "Set mux select to connect target to spi flash 2 (SBS Dual)",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_sbs_run,
     },
     {
         .verbs = (const char*[]){"i2c", I2C_DETECT_CMD_STR, NULL},

--- a/examples/htool_sbs.c
+++ b/examples/htool_sbs.c
@@ -1,0 +1,67 @@
+#include "htool_sbs.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "host_commands.h"
+#include "htool_cmd.h"
+#include "htool_target_control.h"
+
+static int sbs_perform_action(enum hoth_target_control_action action) {
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(HOTH_TARGET_CONTROL_SBS_MUX, action,
+                                          &response);
+  if (ret) {
+    return ret;
+  }
+  printf("Previous SBS Mux State: %s\n",
+         response.status == HOTH_TARGET_CONTROL_STATUS_ENABLED ? "enabled"
+                                                              : "disabled");
+  return 0;
+}
+
+static int sbs_get_status(void) {
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(
+      HOTH_TARGET_CONTROL_SBS_MUX, HOTH_TARGET_CONTROL_ACTION_GET_STATUS,
+      &response);
+  if (ret) {
+    return ret;
+  }
+
+  switch (response.status) {
+    case HOTH_TARGET_CONTROL_SBS_MUX_TARGET_CONNECTED_TO_SPI_FLASH_0:
+      printf("Target connected to spi flash 0 / Flash connected to RoT\n");
+      break;
+    case HOTH_TARGET_CONTROL_SBS_MUX_TARGET_CONNECTED_TO_SPI_FLASH_1:
+      printf("Target connected to spi flash 1 / Flash connected to target\n");
+      break;
+    default:
+      printf("Unknown\n");
+      break;
+  }
+  return 0;
+}
+
+int htool_sbs_run(const struct htool_invocation* inv) {
+  const char* subcommand = inv->cmd->verbs[1];
+  if (strcmp(subcommand, SBS_GET_CMD_STR) == 0) {
+    return sbs_get_status();
+  } else if (strcmp(subcommand, SBS_CONNECT_FLASH_TO_ROT_CMD_STR) == 0) {
+    return sbs_perform_action(HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_FLASH_TO_ROT);
+  } else if (strcmp(subcommand, SBS_CONNECT_FLASH_TO_TARGET_CMD_STR) == 0) {
+    return sbs_perform_action(HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_FLASH_TO_TARGET);
+  } else if (strcmp(subcommand,
+                    SBS_CONNECT_TARGET_TO_SPI_FLASH_0_CMD_STR) == 0) {
+    return sbs_perform_action(
+        HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_TARGET_TO_SPI_FLASH_0);
+  } else if (strcmp(subcommand,
+                    SBS_CONNECT_TARGET_TO_SPI_FLASH_1_CMD_STR) == 0) {
+    return sbs_perform_action(
+        HOTH_TARGET_CONTROL_ACTION_SBS_MUX_CONNECT_TARGET_TO_SPI_FLASH_1);
+  } else {
+    fprintf(stderr, "Invalid subcommand: %s\n", subcommand);
+    return -1;
+  }
+  return 0;
+}

--- a/examples/htool_sbs.h
+++ b/examples/htool_sbs.h
@@ -1,0 +1,16 @@
+#ifndef HTOOL_SBS_H_
+#define HTOOL_SBS_H_
+
+#include "htool_cmd.h"
+
+#define SBS_GET_CMD_STR "get"
+#define SBS_CONNECT_FLASH_TO_ROT_CMD_STR "connect_flash_to_rot"
+#define SBS_CONNECT_FLASH_TO_TARGET_CMD_STR "connect_flash_to_target"
+#define SBS_CONNECT_TARGET_TO_SPI_FLASH_0_CMD_STR \
+  "connect_target_to_spi_flash_0"
+#define SBS_CONNECT_TARGET_TO_SPI_FLASH_1_CMD_STR \
+  "connect_target_to_spi_flash_1"
+
+int htool_sbs_run(const struct htool_invocation* inv);
+
+#endif  // HTOOL_SBS_H_

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -34,6 +34,7 @@ executable(
         'htool_spi.c',
         'htool_statistics.c',
         'htool_target_control.c',
+        'htool_sbs.c',
         'htool_usb.c',
         'htool_secure_boot.h',
         'htool_secure_boot.c',


### PR DESCRIPTION
This commit adds a new sbs command to htool to control the side-by-side (SBS) SPI mux.