### PR TITLE
[protocol] Add the payload update confirm features cmds

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -997,6 +997,31 @@ static const struct htool_cmd CMDS[] = {
         .func = htool_payload_update,
     },
     {
+        .verbs = (const char*[]){"payload", "confirm", NULL},
+        .desc = "Finish a payload update confirmation.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_payload_update_confirm,
+    },
+    {
+        .verbs = (const char*[]){"payload", "get_timeout", NULL},
+        .desc = "Get the current payload update confirmation timeout.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_payload_update_confirm_get_staged_timeout,
+    },
+    {
+        .verbs = (const char*[]){"payload", "timeout_enable", NULL},
+        .desc =
+            "Enable/Disable the timeout mechanism for payload update confirm",
+        .params =
+            (const struct htool_param[]){
+                {HTOOL_FLAG_BOOL, 'e', "enable", "true",
+                 .desc = "Enable confirm mode"},
+                {HTOOL_FLAG_VALUE, 't', "timeout", "0",
+                 .desc = "Timeout in seconds"},
+                {}},
+        .func = htool_payload_update_confirm_enable,
+    },
+    {
         .verbs = (const char*[]){"payload", "read", NULL},
         .desc = "Read content of staging flash for Titan images.",
         .params =

--- a/examples/htool_payload_update.c
+++ b/examples/htool_payload_update.c
@@ -286,3 +286,71 @@ int htool_payload_update_verify(const struct htool_invocation* inv) {
   }
   return 0;
 }
+
+int htool_payload_update_confirm(const struct htool_invocation* inv) {
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  int ret = 0;
+
+  ret = libhoth_payload_update_confirm(dev);
+  if (ret != 0) {
+    fprintf(stderr, "Failed to confirm payload update\n");
+    return -1;
+  }
+
+  return ret;
+}
+
+int htool_payload_update_confirm_get_staged_timeout(
+    const struct htool_invocation* inv) {
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  payload_update_confirm_response_t response = {0};
+
+  int ret = libhoth_payload_update_confirm_get_staged_timeout(dev, &response);
+  if (ret != 0) {
+    fprintf(stderr, "Failed to get payload update timeout\n");
+    return -1;
+  }
+
+  printf("Current timeout: %u seconds\n", response.timeouts.current);
+  printf("Current MIN timeout: %u seconds\n", response.timeouts.min);
+  printf("Current MAX timeout: %u seconds\n", response.timeouts.max);
+  printf("Current default timeout: %u seconds\n",
+         response.timeouts.default_val);
+
+  return 0;
+}
+
+int htool_payload_update_confirm_enable(const struct htool_invocation* inv) {
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  int ret = 0;
+
+  uint32_t timeout = 0;
+  if (htool_get_param_u32(inv, "timeout", &timeout)) {
+    return -1;
+  }
+
+  bool enable_confirm = true;
+  if (htool_get_param_bool(inv, "enable", &enable_confirm)) {
+    return -1;
+  }
+
+  ret = libhoth_payload_update_confirm_enable(dev, enable_confirm, timeout);
+  if (ret != 0) {
+    fprintf(stderr, "Failed to confirm payload update\n");
+    return -1;
+  }
+
+  return ret;
+}

--- a/examples/htool_payload_update.h
+++ b/examples/htool_payload_update.h
@@ -29,7 +29,10 @@ int htool_payload_update_getstatus(const struct htool_invocation* inv);
 int htool_payload_erase(const struct htool_invocation* inv);
 int htool_payload_activate(const struct htool_invocation* inv);
 int htool_payload_update_verify(const struct htool_invocation* inv);
-
+int htool_payload_update_confirm(const struct htool_invocation* inv);
+int htool_payload_update_confirm_get_staged_timeout(
+    const struct htool_invocation* inv);
+int htool_payload_update_confirm_enable(const struct htool_invocation* inv);
 #ifdef __cplusplus
 }
 #endif

--- a/protocol/payload_update.c
+++ b/protocol/payload_update.c
@@ -27,6 +27,12 @@
 #include "transports/libhoth_device.h"
 #include "util.h"
 
+#define PAYLOAD_UPDATE_CONFIRM_OP_ENABLE 0
+#define PAYLOAD_UPDATE_CONFIRM_OP_ENABLE_WITH_TIMEOUT 1
+#define PAYLOAD_UPDATE_CONFIRM_OP_DISABLE 2
+#define PAYLOAD_UPDATE_CONFIRM_OP_CONFIRM 3
+#define PAYLOAD_UPDATE_CONFIRM_OP_GET_STAGED_TIMEOUT_VALUES 4
+
 static int send_payload_update_request_with_command(struct libhoth_device* dev,
                                                     uint8_t command) {
   struct payload_update_packet request;
@@ -386,4 +392,103 @@ int libhoth_payload_update_verify(struct libhoth_device* dev) {
 int libhoth_payload_update_verify_descriptor(struct libhoth_device* dev) {
   return send_payload_update_request_with_command(
       dev, PAYLOAD_UPDATE_VERIFY_DESCRIPTOR);
+}
+
+int libhoth_payload_update_confirm(struct libhoth_device* dev) {
+  payload_update_confirm_response_t confirm_response = {0};
+
+  payload_update_confirm_request_t confirm_request = {0};
+  confirm_request.op = PAYLOAD_UPDATE_CONFIRM_OP_CONFIRM;
+
+  struct payload_update_packet pkt_header = {
+      .type = PAYLOAD_UPDATE_CONFIRM,
+      .offset = 0,
+      .len = sizeof(confirm_request),
+  };
+
+  uint8_t send_buf[sizeof(pkt_header) + sizeof(confirm_request)] = {0};
+  memcpy(&send_buf[0], &pkt_header, sizeof(pkt_header));
+  memcpy(&send_buf[sizeof(pkt_header)], &confirm_request,
+         sizeof(confirm_request));
+
+  int ret = libhoth_hostcmd_exec(
+      dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
+      &send_buf, sizeof(send_buf), &confirm_response, sizeof(confirm_response),
+      NULL);
+  if (ret != 0) {
+    fprintf(stderr, "Payload update confirm failed, err code: %d\n", ret);
+    return -1;
+  }
+
+  return 0;
+}
+
+int libhoth_payload_update_confirm_enable(struct libhoth_device* dev,
+                                          bool enable,
+                                          uint32_t timeout_seconds) {
+  payload_update_confirm_response_t confirm_response = {0};
+
+  // Initially fill timeout with the set timeout, if enabled
+  // Later we will adjust timeout to default if not explicitly defined here
+  payload_update_confirm_request_t confirm_request = {0};
+  confirm_request.op = enable ? PAYLOAD_UPDATE_CONFIRM_OP_ENABLE_WITH_TIMEOUT
+                              : PAYLOAD_UPDATE_CONFIRM_OP_DISABLE;
+
+  confirm_request.timeout = timeout_seconds;
+
+  struct payload_update_packet pkt_header = {
+      .type = PAYLOAD_UPDATE_CONFIRM,
+      .offset = 0,
+      .len = sizeof(confirm_request),
+  };
+
+  // timout_seconds of 0 is treated as a special value to use the default
+  // timeout value defined in the firmware.
+  if (timeout_seconds == 0 && enable == true) {
+    confirm_request.op = PAYLOAD_UPDATE_CONFIRM_OP_ENABLE;
+  }
+
+  uint8_t send_buf[sizeof(pkt_header) + sizeof(confirm_request)] = {0};
+  memcpy(&send_buf[0], &pkt_header, sizeof(pkt_header));
+  memcpy(&send_buf[sizeof(pkt_header)], &confirm_request,
+         sizeof(confirm_request));
+
+  int ret = libhoth_hostcmd_exec(
+      dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
+      &send_buf, sizeof(send_buf), &confirm_response, sizeof(confirm_response),
+      NULL);
+  if (ret != 0) {
+    fprintf(stderr, "Payload update confirm enable failed, err code: %d\n",
+            ret);
+    return -1;
+  }
+
+  return 0;
+}
+
+int libhoth_payload_update_confirm_get_staged_timeout(
+    struct libhoth_device* dev, payload_update_confirm_response_t* response) {
+  payload_update_confirm_request_t confirm_request = {0};
+  confirm_request.op = PAYLOAD_UPDATE_CONFIRM_OP_GET_STAGED_TIMEOUT_VALUES;
+
+  struct payload_update_packet pkt_header = {
+      .type = PAYLOAD_UPDATE_CONFIRM,
+      .offset = 0,
+      .len = sizeof(confirm_request),
+  };
+
+  uint8_t send_buf[sizeof(pkt_header) + sizeof(confirm_request)] = {0};
+  memcpy(&send_buf[0], &pkt_header, sizeof(pkt_header));
+  memcpy(&send_buf[sizeof(pkt_header)], &confirm_request,
+         sizeof(confirm_request));
+
+  int ret = libhoth_hostcmd_exec(
+      dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PAYLOAD_UPDATE, 0,
+      &send_buf, sizeof(send_buf), response, sizeof(*response), NULL);
+  if (ret != 0) {
+    fprintf(stderr, "Payload update get timeout failed, err code: %d\n", ret);
+    return -1;
+  }
+
+  return 0;
 }

--- a/protocol/payload_update.h
+++ b/protocol/payload_update.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -39,6 +40,60 @@ extern "C" {
 #define PAYLOAD_UPDATE_CONFIRM 10
 #define PAYLOAD_UPDATE_VERIFY_DESCRIPTOR 11
 
+typedef uint32_t payload_update_confirm_seconds;
+typedef uint8_t payload_update_confirm_op;
+
+static const payload_update_confirm_seconds
+    PAYLOAD_UPDATE_CONFIRM_SECONDS_ZERO = 0;
+static const payload_update_confirm_seconds PAYLOAD_UPDATE_CONFIRM_SECONDS_MIN =
+    30;
+static const payload_update_confirm_seconds PAYLOAD_UPDATE_CONFIRM_SECONDS_MAX =
+    60 * 60;
+static const payload_update_confirm_seconds
+    PAYLOAD_UPDATE_CONFIRM_SECONDS_DEFAULT = 15 * 60;
+
+typedef struct {
+  payload_update_confirm_seconds min;
+  payload_update_confirm_seconds max;
+  payload_update_confirm_seconds default_val;
+  payload_update_confirm_seconds current;
+} payload_update_confirm_timeouts_t;
+static_assert(sizeof(payload_update_confirm_timeouts_t) == 16,
+              "Unexpected struct size for payload_update_confirm_timeouts_t");
+static_assert(offsetof(payload_update_confirm_timeouts_t, min) == 0,
+              "Unexpected offset for min");
+static_assert(offsetof(payload_update_confirm_timeouts_t, max) == 4,
+              "Unexpected offset for max");
+static_assert(offsetof(payload_update_confirm_timeouts_t, default_val) == 8,
+              "Unexpected offset for default_val");
+static_assert(offsetof(payload_update_confirm_timeouts_t, current) == 12,
+              "Unexpected offset for current");
+
+typedef struct {
+  payload_update_confirm_op op;
+  uint8_t padding[3];
+  payload_update_confirm_seconds timeout;
+  uint64_t cookie;
+} payload_update_confirm_request_t;
+static_assert(offsetof(payload_update_confirm_request_t, op) == 0,
+              "Unexpected offset for op");
+static_assert(offsetof(payload_update_confirm_request_t, padding) == 1,
+              "Unexpected offset for padding");
+static_assert(offsetof(payload_update_confirm_request_t, timeout) == 4,
+              "Unexpected offset for timeout");
+static_assert(offsetof(payload_update_confirm_request_t, cookie) == 8,
+              "Unexpected offset for cookie");
+static_assert(sizeof(payload_update_confirm_request_t) == 16,
+              "Unexpected struct size for payload_update_confirm_request_t");
+
+typedef struct {
+  payload_update_confirm_timeouts_t timeouts;
+} payload_update_confirm_response_t;
+static_assert(offsetof(payload_update_confirm_response_t, timeouts) == 0, "");
+static_assert(sizeof(payload_update_confirm_response_t) ==
+                  sizeof(payload_update_confirm_timeouts_t),
+              "");
+
 struct payload_update_status {
   uint8_t a_valid;         /* 0 = invalid, 1 = unverified, 2 = valid, */
                            /* 3 = descriptor valid */
@@ -48,6 +103,18 @@ struct payload_update_status {
   uint8_t next_half;       /* 0, 1 */
   uint8_t persistent_half; /* 0, 1 */
 } __attribute__((packed));
+static_assert(sizeof(struct payload_update_status) == 5,
+              "Unexpected struct size");
+static_assert(offsetof(struct payload_update_status, a_valid) == 0,
+              "Unexpected offset for a_valid");
+static_assert(offsetof(struct payload_update_status, b_valid) == 1,
+              "Unexpected offset for b_valid");
+static_assert(offsetof(struct payload_update_status, active_half) == 2,
+              "Unexpected offset for active_half");
+static_assert(offsetof(struct payload_update_status, next_half) == 3,
+              "Unexpected offset for next_half");
+static_assert(offsetof(struct payload_update_status, persistent_half) == 4,
+              "Unexpected offset for persistent_half");
 
 enum payload_update_err {
   PAYLOAD_UPDATE_OK = 0,
@@ -68,6 +135,14 @@ struct payload_update_packet {
   uint8_t type;    /* One of PAYLOAD_UPDATE_* */
   /* payload data immediately follows */
 } __attribute__((packed));
+static_assert(sizeof(struct payload_update_packet) == 9,
+              "Unexpected struct size");
+static_assert(offsetof(struct payload_update_packet, offset) == 0,
+              "Unexpected offset for offset");
+static_assert(offsetof(struct payload_update_packet, len) == 4,
+              "Unexpected offset for len");
+static_assert(offsetof(struct payload_update_packet, type) == 8,
+              "Unexpected offset for type");
 
 struct payload_update_finalize_response_v1 {
   // Non-zero if configuration currently running on PLD needs to be
@@ -109,6 +184,13 @@ enum payload_update_err libhoth_payload_update_activate(
     uint8_t* pld_needs_reinitialization);
 int libhoth_payload_update_verify(struct libhoth_device* dev);
 int libhoth_payload_update_verify_descriptor(struct libhoth_device* dev);
+int libhoth_payload_update_confirm(struct libhoth_device* dev);
+int libhoth_payload_update_confirm_enable(struct libhoth_device* dev,
+                                          bool enable,
+                                          uint32_t timeout_seconds);
+int libhoth_payload_update_confirm_get_staged_timeout(
+    struct libhoth_device* dev,
+    payload_update_confirm_response_t* timeout_seconds);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This seeks to add payload update confirm cmds for get, enable, disable,
and confirm. This are the standard feature that is needed to interact
with payload update confirm.