### PR TITLE
Add host command to enable/disable JTAG debug

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -180,6 +180,8 @@ cc_binary(
         "htool_console.h",
         "htool_constants.h",
         "htool_dbus.c",
+        "htool_debug.c",
+        "htool_debug.h",
         "htool_dfu.c",
         "htool_dfu.h",
         "htool_firmware_update.c",

--- a/examples/host_commands.h
+++ b/examples/host_commands.h
@@ -311,7 +311,8 @@ enum hoth_target_control_action {
 };
 
 enum hoth_target_control_function {
-  HOTH_TARGET_CONTROL_RESERVED0 = 0,
+  // Allow control over GPIO for Jtag debug enable (if present)
+  HOTH_TARGET_CONTROL_DEBUG = 0,
   HOTH_TARGET_CONTROL_RESERVED1 = 1,
   // Allow control over GPIO for I2C Mux select (if present)
   HOTH_TARGET_CONTROL_I2C_MUX = 2,

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -32,6 +32,7 @@
 #include "htool_authz_command.h"
 #include "htool_cmd.h"
 #include "htool_console.h"
+#include "htool_debug.h"
 #include "htool_dfu.h"
 #include "htool_firmware_update.h"
 #include "htool_i2c.h"
@@ -927,6 +928,24 @@ static const struct htool_cmd CMDS[] = {
         .desc = "Quickly put the target device in and out of reset",
         .params = (const struct htool_param[]){{}},
         .func = command_target_reset_pulse,
+    },
+    {
+        .verbs = (const char*[]){"target", "debug", "enable", NULL},
+        .desc = "Enable target debug.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_enable,
+    },
+    {
+        .verbs = (const char*[]){"target", "debug", "disable", NULL},
+        .desc = "Disable target debug.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_disable,
+    },
+    {
+        .verbs = (const char*[]){"target", "debug", "get", NULL},
+        .desc = "Get target debug status.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_get,
     },
     {
         .verbs = (const char*[]){"console", NULL},

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -32,6 +32,7 @@
 #include "htool_authz_command.h"
 #include "htool_cmd.h"
 #include "htool_console.h"
+#include "htool_debug.h"
 #include "htool_dfu.h"
 #include "htool_firmware_update.h"
 #include "htool_i2c.h"
@@ -927,6 +928,24 @@ static const struct htool_cmd CMDS[] = {
         .desc = "Quickly put the target device in and out of reset",
         .params = (const struct htool_param[]){{}},
         .func = command_target_reset_pulse,
+    },
+    {
+        .verbs = (const char*[]){"target_debug", "enable", NULL},
+        .desc = "Enable target debug.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_enable,
+    },
+    {
+        .verbs = (const char*[]){"target_debug", "disable", NULL},
+        .desc = "Disable target debug.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_disable,
+    },
+    {
+        .verbs = (const char*[]){"target_debug", "get", NULL},
+        .desc = "Get target debug status.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_target_debug_get,
     },
     {
         .verbs = (const char*[]){"console", NULL},

--- a/examples/htool_debug.c
+++ b/examples/htool_debug.c
@@ -1,0 +1,64 @@
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "htool_debug.h"
+
+#include <stdio.h>
+
+#include "host_commands.h"
+#include "htool_target_control.h"
+int htool_target_debug_enable(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(
+      HOTH_TARGET_CONTROL_DEBUG, HOTH_TARGET_CONTROL_ACTION_ENABLE, &response);
+  if (ret != 0) {
+    return ret;
+  }
+  printf("Target debug enabled.\n");
+  return 0;
+}
+int htool_target_debug_disable(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(
+      HOTH_TARGET_CONTROL_DEBUG, HOTH_TARGET_CONTROL_ACTION_DISABLE, &response);
+  if (ret != 0) {
+    return ret;
+  }
+  printf("Target debug disabled.\n");
+  return 0;
+}
+int htool_target_debug_get(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(HOTH_TARGET_CONTROL_DEBUG,
+                                          HOTH_TARGET_CONTROL_ACTION_GET_STATUS,
+                                          &response);
+  if (ret != 0) {
+    return ret;
+  }
+  switch (response.status) {
+    case HOTH_TARGET_CONTROL_STATUS_ENABLED:
+      printf("Target debug status: Enabled\n");
+      break;
+    case HOTH_TARGET_CONTROL_STATUS_DISABLED:
+      printf("Target debug status: Disabled\n");
+      break;
+    default:
+      printf("Target debug status: Unknown\n");
+      break;
+  }
+  return 0;
+}

--- a/examples/htool_debug.c
+++ b/examples/htool_debug.c
@@ -1,0 +1,64 @@
+
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "htool_debug.h"
+
+#include <stdio.h>
+
+#include "host_commands.h"
+#include "htool_target_control.h"
+int htool_target_debug_enable(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(
+      HOTH_TARGET_CONTROL_DEBUG, HOTH_TARGET_CONTROL_ACTION_ENABLE, &response);
+  if (ret != 0) {
+    return ret;
+  }
+  printf("Target debug enabled.\n");
+  return 0;
+}
+int htool_target_debug_disable(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(
+      HOTH_TARGET_CONTROL_DEBUG, HOTH_TARGET_CONTROL_ACTION_DISABLE, &response);
+  if (ret != 0) {
+    return ret;
+  }
+  printf("Target debug disabled.\n");
+  return 0;
+}
+int htool_target_debug_get(const struct htool_invocation* inv) {
+  (void)inv;
+  struct hoth_response_target_control response;
+  int ret = target_control_perform_action(HOTH_TARGET_CONTROL_DEBUG,
+                                          HOTH_TARGET_CONTROL_ACTION_GET_STATUS,
+                                          &response);
+  if (ret != 0) {
+    return ret;
+  }
+  switch (response.status) {
+    case HOTH_TARGET_CONTROL_STATUS_ENABLED:
+      printf("Target debug status: Enabled\n");
+      break;
+    case HOTH_TARGET_CONTROL_STATUS_DISABLED:
+      printf("Target debug status: Disabled\n");
+      break;
+    default:
+      printf("Target debug status: Unknown\n");
+      break;
+  }
+  return 0;
+}

--- a/examples/htool_debug.h
+++ b/examples/htool_debug.h
@@ -1,0 +1,31 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_
+#define LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Forward declaration
+struct htool_invocation;
+int htool_target_debug_enable(const struct htool_invocation* inv);
+int htool_target_debug_disable(const struct htool_invocation* inv);
+int htool_target_debug_get(const struct htool_invocation* inv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_

--- a/examples/htool_debug.h
+++ b/examples/htool_debug.h
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_
+#define LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Forward declaration
+struct htool_invocation;
+int htool_target_debug_enable(const struct htool_invocation* inv);
+int htool_target_debug_disable(const struct htool_invocation* inv);
+int htool_target_debug_get(const struct htool_invocation* inv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LIBHOTH_EXAMPLES_HTOOL_DEBUG_H_

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -23,6 +23,8 @@ executable(
         'htool_cmd.c',
         'htool_console.c',
         'htool_dbus.c',
+        'htool_debug.c',
+        'htool_debug.h',
         'htool_dfu.c',
         'htool_firmware_update.c',
         'htool_i2c.c',


### PR DESCRIPTION
Note: This will stop working once authorized host commands are supported