### PR TITLE
[protocol] Add the implementation of get mauv

### DIFF
--- a/protocol/mauv.c
+++ b/protocol/mauv.c
@@ -14,9 +14,35 @@
 
 #include "mauv.h"
 
-int libhoth_get_mauv(struct libhoth_device* dev, uint8_t state,
-                     uint8_t category, struct hoth_response_mauv* mauv) {
-  // TODO: implement this later. For now just return a dummy value.
+#include <stddef.h>
+#include <stdint.h>
+
+#include "protocol/host_cmd.h"
+
+int libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
+                       uint8_t category, struct hoth_response_mauv* mauv) {
+  struct mauv_request request = {
+      .category = category,
+      .state = state,
+      .reserved_0 = 0,
+  };
+
+  size_t rlen = 0;
+  int ret = libhoth_hostcmd_exec(
+      dev, HOTH_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HAVEN_MAUV, 0, &request,
+      sizeof(request), mauv, sizeof(*mauv), &rlen);
+  if (ret != 0) {
+    return ret;
+  }
+
+  if (rlen == sizeof(uint32_t)) {
+    // Old version response: only returns the version number.
+    return 0;
+  }
+
+  if (rlen != sizeof(struct hoth_response_mauv)) {
+    return -1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
This seeks to fill the stub on the function libhoth_get_mauv. We are
just trying to get back the MAUV version given a set of parameters.
