### PR TITLE
[htool] Add support to payload for payload mauv compile

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -1100,6 +1100,18 @@ static const struct htool_cmd CMDS[] = {
         .func = htool_payload_info,
     },
     {
+        .verbs = (const char*[]){"payload", "mauv", "compiled", NULL},
+        .desc = "Display compiled MAUV for the payload.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_get_compiled_payload_mauv,
+    },
+    {
+        .verbs = (const char*[]){"payload", "mauv", "effective", NULL},
+        .desc = "Display effective MAUV for the payload.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_get_effective_payload_mauv,
+    },
+    {
         .verbs = (const char*[]){"firmware_update",
                                  "update_from_flash_and_reset", NULL},
         .desc = "Installs a firmware update from a bundle staged in the "

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -1145,6 +1145,18 @@ static const struct htool_cmd CMDS[] = {
         .func = htool_payload_info,
     },
     {
+        .verbs = (const char*[]){"payload", "mauv", "compiled", NULL},
+        .desc = "Display compiled MAUV for the payload.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_get_compiled_payload_mauv,
+    },
+    {
+        .verbs = (const char*[]){"payload", "mauv", "effective", NULL},
+        .desc = "Display effective MAUV for the payload.",
+        .params = (const struct htool_param[]){{}},
+        .func = htool_get_effective_payload_mauv,
+    },
+    {
         .verbs = (const char*[]){"firmware_update",
                                  "update_from_flash_and_reset", NULL},
         .desc = "Installs a firmware update from a bundle staged in the "

--- a/examples/htool_payload.c
+++ b/examples/htool_payload.c
@@ -28,6 +28,7 @@
 
 #include "host_commands.h"
 #include "htool.h"
+#include "protocol/mauv.h"
 #include "protocol/payload_info.h"
 #include "protocol/payload_status.h"
 
@@ -287,4 +288,41 @@ int htool_payload_info_nonstatic(const struct htool_invocation* inv) {
   print_regions(&info_all, /*skip_mask=*/IMAGE_REGION_STATIC);
 
   return htool_payload_image_close(&img);
+}
+
+int htool_get_compiled_payload_mauv(const struct htool_invocation* inv) {
+  (void)inv;
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  struct hoth_response_mauv mauv_resp = {0};
+  int ret =
+      libhoth_fetch_mauv(dev, MAUV_STATE_COMPILED, IMAGE_MAUV, &mauv_resp);
+  if (ret != 0) {
+    fprintf(stderr, "libhoth_fetch_mauv error: %d\n", ret);
+    return -1;
+  }
+
+  const struct image_mauv* mauv = &mauv_resp.image;
+
+  printf("Payload MAUV (Compiled):\n");
+  printf("  Struct Version: %u\n", mauv->mauv_struct_version);
+  printf("  Security Version: %" PRIu64 "\n", mauv->payload_security_version);
+  printf("  Update Timestamp: %" PRIu64 "\n", mauv->mauv_update_timestamp);
+  printf("  Min Acceptable Version: %" PRIu64 "\n",
+         mauv->minimum_acceptable_update_version);
+  printf("  Denylist Entries: %u\n", mauv->version_denylist_num_entries);
+
+  for (uint32_t i = 0; i < mauv->version_denylist_num_entries; i++) {
+    printf("    [%u]: %" PRIu64 "\n", i, mauv->version_denylist[i]);
+  }
+
+  return 0;
+}
+
+int htool_get_effective_payload_mauv(const struct htool_invocation* inv) {
+  // TODO: implement once effective payload MAUV is supported in firmware.
+  return 0;
 }

--- a/examples/htool_payload.h
+++ b/examples/htool_payload.h
@@ -28,6 +28,8 @@ int htool_payload_status(const struct htool_invocation* inv);
 int htool_payload_info(const struct htool_invocation* inv);
 int htool_payload_info_all(const struct htool_invocation* inv);
 int htool_payload_info_nonstatic(const struct htool_invocation* inv);
+int htool_get_compiled_payload_mauv(const struct htool_invocation* inv);
+int htool_get_effective_payload_mauv(const struct htool_invocation* inv);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
We are adding to the existing payload command to allow for an additional
option of reading back the compiled payload mauv. This is a set of
features that are aligned with the overall mauv support.