### PR TITLE
[protocol] Add the set mauv record support in htool

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -46,6 +46,9 @@ cc_library(
 cc_library(
     name = "htool_header",
     hdrs = ["htool.h"],
+    deps = [
+        "//protocol:libhoth_status",
+    ],
 )
 
 cc_library(
@@ -253,6 +256,7 @@ cc_binary(
         "//protocol:i2c",
         "//protocol:jtag",
         "//protocol:key_rotation",
+        "//protocol:libhoth_status",
         "//protocol:mauv",
         "//protocol:opentitan_version",
         "//protocol:panic",

--- a/examples/htool.c
+++ b/examples/htool.c
@@ -71,7 +71,7 @@
 #include "transports/libhoth_device.h"
 #include "transports/libhoth_spi.h"
 
-static void htool_report_error(const char* cmd_name, libhoth_error err) {
+void htool_report_error(const char* cmd_name, libhoth_error err) {
   if (err == HOTH_SUCCESS) {
     return;
   }
@@ -1983,6 +1983,17 @@ static const struct htool_cmd CMDS[] = {
         .params = (const struct htool_param[]){{}},
         .func = htool_mauv_effective,
     },
+    {
+        .verbs = (const char*[]){"mauv", "update", NULL},
+        .desc = "Update MAUV using a signed MAUV record file.",
+        .params =
+            (const struct htool_param[]){
+                {HTOOL_POSITIONAL, .name = "record-file",
+                 .desc = "A signed MAUV record file."},
+                {}},
+        .func = htool_mauv_update,
+    },
+
     {
         .verbs = (const char*[]){"tpm", "get_mode", NULL},
         .desc = "Get the current TPM mode.",

--- a/examples/htool.h
+++ b/examples/htool.h
@@ -18,11 +18,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "protocol/status.h"
+
 #define HTOOL_ERROR_HOST_COMMAND_START 537200
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void htool_report_error(const char* cmd_name, libhoth_error err);
 
 struct libhoth_device;
 

--- a/examples/htool_mauv.c
+++ b/examples/htool_mauv.c
@@ -14,9 +14,15 @@
 
 #include "htool_mauv.h"
 
+#include <errno.h>
+#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "htool.h"
 #include "protocol/mauv.h"
@@ -45,9 +51,10 @@ int htool_mauv_compiled(const struct htool_invocation* inv) {
   }
 
   struct hoth_response_mauv mauv;
-  int ret = libhoth_fetch_mauv(dev, MAUV_STATE_COMPILED, HAVEN_MAUV, &mauv);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to get compiled firmware MAUV: %d\n", ret);
+  libhoth_error err =
+      libhoth_fetch_mauv(dev, MAUV_STATE_COMPILED, HAVEN_MAUV, &mauv);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("fetch_mauv", err);
     return -1;
   }
 
@@ -57,5 +64,67 @@ int htool_mauv_compiled(const struct htool_invocation* inv) {
 
 int htool_mauv_effective(const struct htool_invocation* inv) {
   // TODO: support FW MAUV effective once it's implemented in firmware.
+  return 0;
+}
+
+int htool_mauv_update(const struct htool_invocation* inv) {
+  struct libhoth_device* dev = htool_libhoth_device();
+  if (!dev) {
+    return -1;
+  }
+
+  const char* record_file;
+  if (htool_get_param_string(inv, "record-file", &record_file)) {
+    return -1;
+  }
+
+  int fd = open(record_file, O_RDONLY);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening file %s: %s\n", record_file,
+            strerror(errno));
+    return -1;
+  }
+
+  struct stat statbuf;
+  if (fstat(fd, &statbuf)) {
+    fprintf(stderr, "fstat error: %s\n", strerror(errno));
+    close(fd);
+    return -1;
+  }
+
+  if (statbuf.st_size > MAUV_MAX_RECORD_SIZE) {
+    fprintf(stderr,
+            "Error: MAUV record file is too large (%ld bytes, max %d)\n",
+            statbuf.st_size, MAUV_MAX_RECORD_SIZE);
+    close(fd);
+    return -1;
+  }
+
+  uint8_t* record_data = malloc(statbuf.st_size);
+  if (!record_data) {
+    fprintf(stderr, "Memory allocation failed\n");
+    close(fd);
+    return -1;
+  }
+
+  ssize_t bytes_read = read(fd, record_data, statbuf.st_size);
+  if (bytes_read != statbuf.st_size) {
+    fprintf(stderr, "Error reading file: %s\n", strerror(errno));
+    free(record_data);
+    close(fd);
+    return -1;
+  }
+  close(fd);
+
+  printf("Sending MAUV update record (%zd bytes)...\n", bytes_read);
+  libhoth_error err = libhoth_update_mauv(dev, record_data, bytes_read);
+  free(record_data);
+
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("update_mauv", err);
+    return -1;
+  }
+
+  printf("MAUV update successful!\n");
   return 0;
 }

--- a/examples/htool_mauv.h
+++ b/examples/htool_mauv.h
@@ -19,5 +19,6 @@
 
 int htool_mauv_compiled(const struct htool_invocation* inv);
 int htool_mauv_effective(const struct htool_invocation* inv);
+int htool_mauv_update(const struct htool_invocation* inv);
 
 #endif  // _LIBHOTH_EXAMPLES_HTOOL_MAUV_H_

--- a/examples/htool_payload.c
+++ b/examples/htool_payload.c
@@ -298,10 +298,10 @@ int htool_get_compiled_payload_mauv(const struct htool_invocation* inv) {
   }
 
   struct hoth_response_mauv mauv_resp = {0};
-  int ret =
+  libhoth_error err =
       libhoth_fetch_mauv(dev, MAUV_STATE_COMPILED, IMAGE_MAUV, &mauv_resp);
-  if (ret != 0) {
-    fprintf(stderr, "libhoth_fetch_mauv error: %d\n", ret);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("fetch_mauv", err);
     return -1;
   }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -577,3 +577,16 @@ cc_library(
         "//transports:libhoth_device",
     ],
 )
+
+cc_test(
+    name = "mauv_test",
+    srcs = ["mauv_test.cc"],
+    deps = [
+        ":mauv",
+        "//protocol/test:libhoth_device_mock",
+        "//transports:libhoth_device",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+

--- a/protocol/mauv.c
+++ b/protocol/mauv.c
@@ -19,8 +19,9 @@
 
 #include "protocol/host_cmd.h"
 
-int libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
-                       uint8_t category, struct hoth_response_mauv* mauv) {
+libhoth_error libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
+                                 uint8_t category,
+                                 struct hoth_response_mauv* mauv) {
   struct mauv_request request = {
       .category = category,
       .state = state,
@@ -28,21 +29,35 @@ int libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
   };
 
   size_t rlen = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_HAVEN_MAUV, 0, &request,
       sizeof(request), mauv, sizeof(*mauv), &rlen);
-  if (ret != 0) {
-    return ret;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
 
   if (rlen == sizeof(uint32_t)) {
     // Old version response: only returns the version number.
-    return 0;
+    return HOTH_SUCCESS;
   }
 
   if (rlen != sizeof(struct hoth_response_mauv)) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return 0;
+  return HOTH_SUCCESS;
+}
+
+libhoth_error libhoth_update_mauv(struct libhoth_device* dev,
+                                  const void* record, size_t record_size) {
+  if (record_size > MAUV_MAX_RECORD_SIZE) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
+  size_t rlen = 0;
+  return libhoth_hostcmd_exec_v2(
+      dev, HOTH_CMD_BOARD_SPECIFIC_BASE + EC_PRV_CMD_UPDATE_MAUV, 0, record,
+      record_size, NULL, 0, &rlen);
 }

--- a/protocol/mauv.h
+++ b/protocol/mauv.h
@@ -31,6 +31,10 @@
  */
 
 #define EC_PRV_CMD_HAVEN_MAUV 0x000B
+#define EC_PRV_CMD_UPDATE_MAUV 0x0057
+
+// Maximum allowed size for an incoming MAUV update record (1016 bytes).
+#define MAUV_MAX_RECORD_SIZE 1016
 
 // Current version of the `haven_mauv` struct.
 #define HAVEN_MAUV_STRUCT_VERSION 1
@@ -187,8 +191,12 @@ struct hoth_response_mauv {
   };
 } __attribute__((packed));
 
-int libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
-                       uint8_t category, struct hoth_response_mauv* mauv);
+libhoth_error libhoth_fetch_mauv(struct libhoth_device* dev, uint8_t state,
+                                 uint8_t category,
+                                 struct hoth_response_mauv* mauv);
+
+libhoth_error libhoth_update_mauv(struct libhoth_device* dev,
+                                  const void* record, size_t record_size);
 
 #ifdef __cplusplus
 }

--- a/protocol/mauv_test.cc
+++ b/protocol/mauv_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protocol/mauv.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "protocol/test/libhoth_device_mock.h"
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Return;
+
+TEST_F(LibHothTest, update_mauv_success) {
+  struct haven_mauv record = {};
+  record.struct_version = HAVEN_MAUV_STRUCT_VERSION;
+  record.mauv_version = 42;
+  record.minimum_acceptable_update_version.epoch = 1;
+  record.minimum_acceptable_update_version.major = 2;
+  record.minimum_acceptable_update_version.minor = 3;
+  record.denylist_num_entries = 1;
+  record.denylist[0].epoch = 4;
+  record.denylist[0].major = 5;
+  record.denylist[0].minor = 6;
+
+  EXPECT_CALL(mock_, send(_, UsesCommand(0x3E57), _))
+      .WillOnce(Return(LIBHOTH_OK));
+  uint32_t dummy;
+  EXPECT_CALL(mock_, receive)
+      .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
+
+  EXPECT_EQ(libhoth_update_mauv(&hoth_dev_, &record, sizeof(record)),
+            HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, update_mauv_too_large) {
+  uint8_t record[MAUV_MAX_RECORD_SIZE + 1] = {0};
+  EXPECT_EQ(libhoth_update_mauv(&hoth_dev_, record, sizeof(record)),
+            LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                  LIBHOTH_ERR_INVALID_PARAMETER));
+}


### PR DESCRIPTION
As the haven/dauntless firmware has support to set the mauv record in memory, we are adding the support in the command to allow htool to sends a record.