### PR TITLE
Export libusb

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,11 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "external/libusb.BUILD",
+    "external/libusb.patch",
+])
+
 cc_library(
     name = "git_version",
     hdrs = [":gen_version_header"],
@@ -13,4 +18,10 @@ genrule(
     cmd = "$(location :print_version_header.sh) > \"$@\"",
     stamp = 1,
     tools = [":print_version_header.sh"],
+)
+
+alias(
+    name = "libusb",
+    actual = "@libusb//:libusb",
+    visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,16 +7,8 @@ module(
 # libusb is not yet available in the Bazel Central Registry
 # (https://registry.bazel.build/).
 
-git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "libusb",
-    build_file = "external/libusb.BUILD",
-    commit = "4239bc3a50014b8e6a5a2a59df1fff3b7469543b",
-    remote = "https://github.com/libusb/libusb",
-    patches = ["external/libusb.patch"],
-    shallow_since = "1649581036 +0200",
-)
+libusb_ext = use_extension("//:libusb_extension.bzl", "libusb_extension")
+use_repo(libusb_ext, "libusb")
 
 bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "rules_cc", version = "0.1.4")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -149,6 +149,36 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//:libusb_extension.bzl%libusb_extension": {
+      "general": {
+        "bzlTransitiveDigest": "Kg4A6Hezv8NY8wC8/H3B1bwXUMcllIk6q4jqElAn4fw=",
+        "usagesDigest": "rjiRLJhi7h3+DxDtluNQgLUery/JZquhHrulJCfFD6I=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "libusb": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:git.bzl%git_repository",
+            "attributes": {
+              "build_file": "@@//:external/libusb.BUILD",
+              "commit": "4239bc3a50014b8e6a5a2a59df1fff3b7469543b",
+              "remote": "https://github.com/libusb/libusb",
+              "patches": [
+                "@@//:external/libusb.patch"
+              ],
+              "shallow_since": "1649581036 +0200"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",

--- a/libusb_extension.bzl
+++ b/libusb_extension.bzl
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def _libusb_extension_impl(ctx):
+    git_repository(
+        name = "libusb",
+        build_file = "@libhoth//:external/libusb.BUILD",
+        commit = "4239bc3a50014b8e6a5a2a59df1fff3b7469543b",
+        remote = "https://github.com/libusb/libusb",
+        patches = ["@libhoth//:external/libusb.patch"],
+        shallow_since = "1649581036 +0200",
+    )
+
+libusb_extension = module_extension(
+    implementation = _libusb_extension_impl,
+)


### PR DESCRIPTION
This change makes the libusb version used by libhoth consumable by dependencies.  This is useful for building other projects that use libhoth (such as hothd) with the same libusb version as htool.