### PR TITLE
Add top level libhoth bazel target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,6 +20,37 @@ genrule(
     tools = [":print_version_header.sh"],
 )
 
+cc_library(
+    name = "libhoth_transports_headers",
+    hdrs = [
+      "//transports:headers",
+    ],
+    include_prefix = "libhoth/transports",
+    strip_include_prefix = "transports",
+)
+
+cc_library(
+    name = "libhoth_transports_headers_legacy",
+    hdrs = [
+      "//transports:headers",
+    ],
+    include_prefix = "transports",
+    strip_include_prefix = "transports",
+)
+
+cc_library(
+    name = "libhoth",
+    deps = [
+        "//transports:libhoth_device",
+        "//transports:libhoth_usb",
+        "//transports:libhoth_spi",
+        "//transports:libhoth_mtd",
+        ":libhoth_transports_headers",
+        ":libhoth_transports_headers_legacy",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "libusb",
     actual = "@libusb//:libusb",

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('libhoth', 'c', 'cpp', license: 'Apache-2.0', version: '0.0.0')
 
 libhoth_include_dirs = include_directories('.')
 
-header_subdirs = ['libhoth']
+header_subdirs = ['libhoth', '.']
 libhoth_objs = []
 libhoth_deps = []
 subdir('transports')

--- a/transports/BUILD
+++ b/transports/BUILD
@@ -67,3 +67,8 @@ cc_library(
         "@libusb",
     ],
 )
+
+filegroup(
+  name = "headers",
+  srcs = glob(["*.h"])
+)


### PR DESCRIPTION
This will be used to consolidate all libhoth features for easy consumption from other projects. It also exports libhoth transport header files to both libhoth/transport/* and transport/*. 