### PR TITLE
[protocol] Convert chipinfo to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -144,8 +144,9 @@ static int command_show_chipinfo(const struct htool_invocation* inv) {
   }
 
   struct hoth_response_chip_info response;
-  int status = libhoth_chipinfo(dev, &response);
-  if (status != 0) {
+  libhoth_error err = libhoth_chipinfo(dev, &response);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("chipinfo", err);
     return -1;
   }
 
@@ -301,9 +302,9 @@ static int command_authz_host_command_build(
   }
 
   struct hoth_response_chip_info chipinfo_resp;
-  int status = libhoth_chipinfo(dev, &chipinfo_resp);
-  if (status != 0) {
-    fprintf(stderr, "Failed to get chip ID. status=%d\n", status);
+  libhoth_error err = libhoth_chipinfo(dev, &chipinfo_resp);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("chipinfo", err);
     return -1;
   }
   if (chipinfo_resp.version != 0) {
@@ -313,7 +314,7 @@ static int command_authz_host_command_build(
   }
 
   struct hoth_authorized_command_get_nonce_response nonce_resp;
-  status = libhoth_hostcmd_exec(
+  int status = libhoth_hostcmd_exec(
       dev,
       HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_GET_AUTHZ_COMMAND_NONCE,
       /*version=*/0, NULL, 0, &nonce_resp, sizeof(nonce_resp), NULL);

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -210,6 +210,7 @@ cc_library(
     hdrs = ["chipinfo.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/authz_record.c
+++ b/protocol/authz_record.c
@@ -59,15 +59,15 @@ libhoth_error libhoth_authz_record_build(struct libhoth_device* dev,
   *(uint32_t*)record->capabilities = capabilities;
 
   struct hoth_response_chip_info chipinfo_resp;
-  int status = libhoth_chipinfo(dev, &chipinfo_resp);
-  if (status != 0) {
-    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
-                                 status);
+  libhoth_error err = libhoth_chipinfo(dev, &chipinfo_resp);
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
   if (chipinfo_resp.version != 0) {
     fprintf(stderr, "Unsupported chipinfo version: %u\n",
             chipinfo_resp.version);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
   record->dev_id_0 =
       chipinfo_resp.data.hoth_device_id.hardware_identity & 0xfffffffful;
@@ -75,7 +75,7 @@ libhoth_error libhoth_authz_record_build(struct libhoth_device* dev,
       (chipinfo_resp.data.hoth_device_id.hardware_identity >> 32);
 
   struct hoth_authz_record_get_nonce_response nonce_resp;
-  libhoth_error err = libhoth_hostcmd_exec_v2(
+  err = libhoth_hostcmd_exec_v2(
       dev,
       HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_GET_AUTHZ_RECORD_NONCE,
       /*version=*/0, NULL, 0, &nonce_resp, sizeof(nonce_resp), NULL);

--- a/protocol/chipinfo.c
+++ b/protocol/chipinfo.c
@@ -14,21 +14,26 @@
 
 #include "chipinfo.h"
 
+#include <stddef.h>
 #include <string.h>
 
 #include "host_cmd.h"
 
-int libhoth_chipinfo(struct libhoth_device* dev,
-                     struct hoth_response_chip_info* chipinfo) {
-  uint8_t resp_buf[OPENTITAN_DEVICE_ID_LEN];  // Max size for new format
-  size_t resp_size;
+libhoth_error libhoth_chipinfo(struct libhoth_device* dev,
+                               struct hoth_response_chip_info* chipinfo) {
+  if (chipinfo == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
 
-  int ret = libhoth_hostcmd_exec(
+  uint8_t resp_buf[OPENTITAN_DEVICE_ID_LEN];  // Max size for new format
+  size_t resp_size = 0;
+
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_CHIP_INFO,
       /*version=*/0, NULL, 0, resp_buf, sizeof(resp_buf), &resp_size);
-
-  if (ret != 0) {
-    return ret;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
 
   if (resp_size == sizeof(struct hoth_device_id)) {
@@ -43,10 +48,11 @@ int libhoth_chipinfo(struct libhoth_device* dev,
            OPENTITAN_DEVICE_ID_LEN);
   } else {
     // Unexpected size
-    return HTOOL_ERROR_HOST_COMMAND_START + HOTH_RES_INVALID_PARAM;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return 0;
+  return HOTH_SUCCESS;
 }
 
 int parse_opentitan_device_id(const uint8_t* src,

--- a/protocol/chipinfo.h
+++ b/protocol/chipinfo.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #define HOTH_PRV_CMD_HOTH_CHIP_INFO 0x0010
@@ -66,8 +67,8 @@ struct hoth_response_chip_info {
   } data;
 };
 
-int libhoth_chipinfo(struct libhoth_device* dev,
-                     struct hoth_response_chip_info* chipinfo);
+libhoth_error libhoth_chipinfo(struct libhoth_device* dev,
+                               struct hoth_response_chip_info* chipinfo);
 
 #ifdef __cplusplus
 }

--- a/protocol/chipinfo_test.cc
+++ b/protocol/chipinfo_test.cc
@@ -68,7 +68,7 @@ TEST_F(LibHothTest, opentitan_chipinfo_test) {
                       Return(LIBHOTH_OK)));
 
   struct hoth_response_chip_info chipinfo;
-  EXPECT_EQ(libhoth_chipinfo(&hoth_dev_, &chipinfo), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_chipinfo(&hoth_dev_, &chipinfo), HOTH_SUCCESS);
 
   EXPECT_EQ(chipinfo.version, 1);
   EXPECT_EQ(memcmp(chipinfo.data.open_titan_device_id, opentitan_data,
@@ -124,4 +124,12 @@ TEST(ChipInfoTest, ParseOpenTitanDeviceId) {
   EXPECT_EQ(parsed.otp_version, 0xDD);
   EXPECT_STREQ(parsed.sku_id_string, "1234");
   EXPECT_EQ(parsed.sku_specific_version, 0xEE);
+}
+
+TEST_F(LibHothTest, chipinfo_null_param_test) {
+  libhoth_error err = libhoth_chipinfo(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_chipinfo off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.
