### PR TITLE
[protocol] Convert command_version to use the new compact error format

### DIFF
--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -182,6 +182,7 @@ cc_library(
     hdrs = ["command_version.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/command_version.c
+++ b/protocol/command_version.c
@@ -14,17 +14,20 @@
 
 #include "command_version.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "host_cmd.h"
 #include "transports/libhoth_device.h"
 
-int libhoth_get_command_versions(struct libhoth_device* dev, uint16_t command,
-                                 uint32_t* version_mask) {
+libhoth_error libhoth_get_command_versions(struct libhoth_device* dev,
+                                           uint16_t command,
+                                           uint32_t* version_mask) {
   if (version_mask == NULL) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
   }
-  return libhoth_hostcmd_exec(dev, HOTH_CMD_GET_CMD_VERSIONS,
-                              /*version=*/1, &command, sizeof(command),
-                              version_mask, sizeof(*version_mask), NULL);
+  return libhoth_hostcmd_exec_v2(dev, HOTH_CMD_GET_CMD_VERSIONS,
+                                 /*version=*/1, &command, sizeof(command),
+                                 version_mask, sizeof(*version_mask), NULL);
 }

--- a/protocol/command_version.h
+++ b/protocol/command_version.h
@@ -21,12 +21,14 @@ extern "C" {
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #define HOTH_CMD_GET_CMD_VERSIONS 0x0008
 
-int libhoth_get_command_versions(struct libhoth_device* dev, uint16_t command,
-                                 uint32_t* version_mask);
+libhoth_error libhoth_get_command_versions(struct libhoth_device* dev,
+                                           uint16_t command,
+                                           uint32_t* version_mask);
 
 #ifdef __cplusplus
 }

--- a/protocol/command_version_test.cc
+++ b/protocol/command_version_test.cc
@@ -37,6 +37,14 @@ TEST_F(LibHothTest, command_version_test) {
 
   uint32_t version_mask;
   EXPECT_EQ(libhoth_get_command_versions(&hoth_dev_, 0x3, &version_mask),
-            LIBHOTH_OK);
+            HOTH_SUCCESS);
   EXPECT_EQ(version_mask, version_mask_exp);
+}
+
+TEST_F(LibHothTest, command_version_null_param_test) {
+  libhoth_error err = libhoth_get_command_versions(&hoth_dev_, 0x3, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }

--- a/protocol/payload_update.c
+++ b/protocol/payload_update.c
@@ -53,18 +53,19 @@ static int send_payload_update_request_with_command(struct libhoth_device* dev,
 static int get_payload_update_version(struct libhoth_device* dev,
                                       uint8_t* version) {
   uint32_t version_mask = 0;
-  const int status = libhoth_get_command_versions(
+  const libhoth_error err = libhoth_get_command_versions(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PAYLOAD_UPDATE,
       &version_mask);
   const bool get_version_unsupported =
-      (status == HTOOL_ERROR_HOST_COMMAND_START + HOTH_RES_INVALID_COMMAND);
-  const bool is_version_0 = (status == 0 && (version_mask & 0x2) == 0);
+      (err == LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_FW,
+                                    HOTH_RES_INVALID_COMMAND));
+  const bool is_version_0 = (err == HOTH_SUCCESS && (version_mask & 0x2) == 0);
   if (get_version_unsupported || is_version_0) {
     *version = 0;
     return 0;
   }
-  if (status != 0) {
-    return status;
+  if (err != HOTH_SUCCESS) {
+    return -1;
   }
   *version = 1;
   return 0;


### PR DESCRIPTION
Migrates libhoth_get_command_versions off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.
