### PR TITLE
[protocol] Convert dfu_hostcmd to use the new compact error format

### DIFF
--- a/examples/htool_dfu.c
+++ b/examples/htool_dfu.c
@@ -168,11 +168,13 @@ int htool_dfu_update(const struct htool_invocation* inv) {
       force ? 2 : dfu_update_count(&desired_rom_ext, &desired_app, &resp);
 
   for (int i = 0; i < update_cnt; i++) {
-    retval = libhoth_dfu_update(dev, image, statbuf.st_size, complete_flags);
+    libhoth_error err =
+        libhoth_dfu_update(dev, image, statbuf.st_size, complete_flags);
 
-    if (retval != 0) {
-      fprintf(stderr, "DFU update failed (%d)\n", retval);
-      libhoth_print_dfu_error(dev, NULL, retval);
+    if (err != HOTH_SUCCESS) {
+      htool_report_error("dfu_update", err);
+      fprintf(stderr, "DFU update failed (0x%016lx)\n", err);
+      libhoth_print_dfu_error(dev, NULL, (int)err);
       retval = -1;
       goto cleanup2;
     }

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -536,6 +536,7 @@ cc_library(
     hdrs = ["dfu_hostcmd.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/dfu_hostcmd.c
+++ b/protocol/dfu_hostcmd.c
@@ -24,14 +24,21 @@ static int generate_random_nonce(struct hoth_dfu_session_id* session_id) {
   return 0;
 }
 
-int libhoth_dfu_update(struct libhoth_device* dev, const uint8_t* image,
-                       size_t image_size, uint32_t complete_flags) {
+libhoth_error libhoth_dfu_update(struct libhoth_device* dev,
+                                 const uint8_t* image, size_t image_size,
+                                 uint32_t complete_flags) {
+  if (image == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
   struct hoth_dfu_session_id session_id = {
       .target = HOTH_DFU_TARGET_EARLGREY_FW_UPDATE,
   };
   if (generate_random_nonce(&session_id) != 0) {
     fprintf(stderr, "Failed to generate random nonce.\n");
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_POSIX,
+                                 LIBHOTH_ERR_FAIL);
   }
 
   struct {
@@ -48,17 +55,18 @@ int libhoth_dfu_update(struct libhoth_device* dev, const uint8_t* image,
     memcpy(request.data, &image[bytes_sent], chunk_len);
 
     size_t response_len;
-    int ret = libhoth_hostcmd_exec(dev, HOTH_CMD_DFU_WRITE, 0, &request,
-                                   sizeof(request.hdr) + chunk_len, NULL, 0,
-                                   &response_len);
-    if (ret != 0) {
-      fprintf(stderr, "DFU write failed with error code: %d\n", ret);
-      return -1;
+    libhoth_error err = libhoth_hostcmd_exec_v2(
+        dev, HOTH_CMD_DFU_WRITE, 0, &request, sizeof(request.hdr) + chunk_len,
+        NULL, 0, &response_len);
+    if (err != HOTH_SUCCESS) {
+      fprintf(stderr, "DFU write failed with error code: 0x%016lx\n", err);
+      return err;
     }
     if (response_len != 0) {
       fprintf(stderr, "DFU write expected 0 response bytes, got %zu\n",
               response_len);
-      return -1;
+      return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                   LIBHOTH_ERR_FAIL);
     }
     bytes_sent += chunk_len;
   }
@@ -72,17 +80,22 @@ int libhoth_dfu_update(struct libhoth_device* dev, const uint8_t* image,
       .flags = complete_flags,
   };
   size_t response_len = 0;
-  int ret =
-      libhoth_hostcmd_exec(dev, HOTH_CMD_DFU_COMPLETE, 0, &complete_request,
-                           sizeof(complete_request), NULL, 0, &response_len);
-  if (ret != 0) {
+  libhoth_error err =
+      libhoth_hostcmd_exec_v2(dev, HOTH_CMD_DFU_COMPLETE, 0, &complete_request,
+                              sizeof(complete_request), NULL, 0, &response_len);
+  if (err != HOTH_SUCCESS) {
     fprintf(stderr,
-            "DFU complete failed with error code: %d; ignoring as the "
+            "DFU complete failed with error code: 0x%016lx; ignoring as the "
             "chip may have already restarted.\n",
-            ret);
+            err);
   }
 
   // TODO: Wait for chip to come back and confirm version
   usleep(LIBHOTH_REBOOT_DELAY_MS * 1000);
-  return libhoth_device_reconnect(dev);
+  int ret = libhoth_device_reconnect(dev);
+  if (ret != LIBHOTH_OK) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 ret);
+  }
+  return HOTH_SUCCESS;
 }

--- a/protocol/dfu_hostcmd.h
+++ b/protocol/dfu_hostcmd.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #include "protocol/host_cmd.h"
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -99,8 +100,9 @@ static_assert(sizeof(struct hoth_dfu_complete_request) == 16, "");
  *                       e.g., HOTH_DFU_COMPLETE_FLAGS_COLD_RESTART.
  * @return 0 on success, -1 on failure.
  */
-int libhoth_dfu_update(struct libhoth_device* dev, const uint8_t* image,
-                       size_t image_size, uint32_t complete_flags);
+libhoth_error libhoth_dfu_update(struct libhoth_device* dev,
+                                 const uint8_t* image, size_t image_size,
+                                 uint32_t complete_flags);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Migrates libhoth_dfu_update off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.