### PR TITLE
[protocol] Convert firmware_update to use the new compact error format

### DIFF
--- a/examples/htool_firmware_update.c
+++ b/examples/htool_firmware_update.c
@@ -29,5 +29,10 @@ int htool_firmware_update(const struct htool_invocation* inv) {
   if (htool_get_param_u32(inv, "offset", &offset)) {
     return -1;
   }
-  return libhoth_firmware_update_from_flash_and_reset(dev, offset);
+  libhoth_error err = libhoth_firmware_update_from_flash_and_reset(dev, offset);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("firmware_update_from_flash", err);
+    return -1;
+  }
+  return 0;
 }

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -361,6 +361,7 @@ cc_library(
     hdrs = ["firmware_update.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/firmware_update.c
+++ b/protocol/firmware_update.c
@@ -20,34 +20,41 @@
 #include "protocol/host_cmd.h"
 #include "transports/libhoth_device.h"
 
-int libhoth_firmware_update_from_flash_and_reset(struct libhoth_device* dev,
-                                                 uint32_t offset) {
+libhoth_error libhoth_firmware_update_from_flash_and_reset(
+    struct libhoth_device* dev, uint32_t offset) {
   const struct hoth_request_firmware_update request = {
       .operation = HOTH_FIRMWARE_UPDATE_OP_UPDATE_AND_RESET,
       .flags = 0,
       .offset = offset,
   };
-  const int rv =
-      libhoth_hostcmd_exec(dev, HOTH_CMD_FIRMWARE_UPDATE, /*version=*/0,
-                           &request, sizeof(request), NULL, 0, NULL);
-  if (rv == 0) {
+  const libhoth_error err =
+      libhoth_hostcmd_exec_v2(dev, HOTH_CMD_FIRMWARE_UPDATE, /*version=*/0,
+                              &request, sizeof(request), NULL, 0, NULL);
+  if (err == HOTH_SUCCESS) {
     fprintf(stderr,
             "Skipped update package at flash offset 0x%x containing same "
             "version as running. Chip is not reset.\n",
             offset);
-    return 0;
+    return HOTH_SUCCESS;
   }
-  if (rv > HTOOL_ERROR_HOST_COMMAND_START) {
+  if (LIBHOTH_ERR_GET_SPACE(err) == HOTH_HOST_SPACE_FW ||
+      LIBHOTH_ERR_GET_SPACE(err) == HOTH_HOST_SPACE_FW_EARLGREY) {
     fprintf(stderr,
             "Firmware update from flash offset 0x%x failed with error code: "
-            "%d. Aborting.\n",
-            offset, rv);
-    return rv;
+            "0x%016lx. Aborting.\n",
+            offset, err);
+    return err;
   }
 
-  fprintf(stderr,
-          "Lost connection after firmware update command (error code %d). "
-          "This is expected if the device reset. Attempting to reconnect...\n",
-          rv);
-  return libhoth_device_reconnect(dev);
+  fprintf(
+      stderr,
+      "Lost connection after firmware update command (error code 0x%016lx). "
+      "This is expected if the device reset. Attempting to reconnect...\n",
+      err);
+  int ret = libhoth_device_reconnect(dev);
+  if (ret != LIBHOTH_OK) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 ret);
+  }
+  return HOTH_SUCCESS;
 }

--- a/protocol/firmware_update.h
+++ b/protocol/firmware_update.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include "protocol/host_cmd.h"
+#include "protocol/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,8 +38,8 @@ struct hoth_request_firmware_update {
   uint32_t offset;     // Bundle offset in the active side of flash.
 } __attribute__((packed, aligned(4)));
 
-int libhoth_firmware_update_from_flash_and_reset(struct libhoth_device* dev,
-                                                 uint32_t offset);
+libhoth_error libhoth_firmware_update_from_flash_and_reset(
+    struct libhoth_device* dev, uint32_t offset);
 
 #ifdef __cplusplus
 }

--- a/protocol/firmware_update_test.cc
+++ b/protocol/firmware_update_test.cc
@@ -36,7 +36,7 @@ TEST_F(LibHothTest, firmware_update_test_skipped) {
   EXPECT_CALL(mock_, reconnect).Times(0);
   EXPECT_EQ(
       libhoth_firmware_update_from_flash_and_reset(&hoth_dev_, /*offset=*/0),
-      0);
+      HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, firmware_update_test_rebooting) {
@@ -47,7 +47,7 @@ TEST_F(LibHothTest, firmware_update_test_rebooting) {
   EXPECT_CALL(mock_, reconnect).WillOnce(Return(LIBHOTH_OK));
   EXPECT_EQ(
       libhoth_firmware_update_from_flash_and_reset(&hoth_dev_, /*offset=*/0),
-      0);
+      HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, firmware_update_test_failed_without_rebooting) {
@@ -64,5 +64,6 @@ TEST_F(LibHothTest, firmware_update_test_failed_without_rebooting) {
   EXPECT_CALL(mock_, reconnect).Times(0);
   EXPECT_EQ(
       libhoth_firmware_update_from_flash_and_reset(&hoth_dev_, /*offset=*/0),
-      HTOOL_ERROR_HOST_COMMAND_START + HOTH_RES_UNAVAILABLE);
+      LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_FW,
+                            HOTH_RES_UNAVAILABLE));
 }


### PR DESCRIPTION
Migrates libhoth_firmware_update_from_flash_and_reset off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.