### PR TITLE
[protocol] Convert gpio_drive_strength to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -878,7 +878,13 @@ static int command_set_gpio_drive_strength(const struct htool_invocation* inv) {
     }
   }
 
-  return libhoth_set_gpio_drive_strength(dev, (uint8_t)pad, (uint8_t)strength);
+  libhoth_error err =
+      libhoth_set_gpio_drive_strength(dev, (uint8_t)pad, (uint8_t)strength);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("set_gpio_drive_strength", err);
+    return -1;
+  }
+  return 0;
 }
 
 static int command_hello(const struct htool_invocation* inv) {

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -425,6 +425,7 @@ cc_library(
     hdrs = ["gpio_drive_strength.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/gpio_drive_strength.c
+++ b/protocol/gpio_drive_strength.c
@@ -19,13 +19,19 @@
 
 #include "protocol/host_cmd.h"
 
-int libhoth_set_gpio_drive_strength(struct libhoth_device* const dev,
-                                    const uint8_t pad, const uint8_t strength) {
+libhoth_error libhoth_set_gpio_drive_strength(struct libhoth_device* const dev,
+                                              const uint8_t pad,
+                                              const uint8_t strength) {
+  if (strength > MAX_GPIO_DRIVE_STRENGTH) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
   const struct hoth_request_set_gpio_drive_strength request = {
       .pad = pad,
       .strength = strength,
   };
-  return libhoth_hostcmd_exec(dev, HOTH_CMD_SET_GPIO_DRIVE_STRENGTH,
-                              /*version=*/0, &request, sizeof(request),
-                              /*response=*/NULL, /*response_size=*/0, NULL);
+  return libhoth_hostcmd_exec_v2(dev, HOTH_CMD_SET_GPIO_DRIVE_STRENGTH,
+                                 /*version=*/0, &request, sizeof(request),
+                                 /*response=*/NULL, /*response_size=*/0, NULL);
 }

--- a/protocol/gpio_drive_strength.h
+++ b/protocol/gpio_drive_strength.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include "protocol/host_cmd.h"
+#include "protocol/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,8 +33,8 @@ struct hoth_request_set_gpio_drive_strength {
   uint8_t strength;
 } __hoth_align1;
 
-int libhoth_set_gpio_drive_strength(struct libhoth_device* dev, uint8_t pad,
-                                    uint8_t strength);
+libhoth_error libhoth_set_gpio_drive_strength(struct libhoth_device* dev,
+                                              uint8_t pad, uint8_t strength);
 
 #ifdef __cplusplus
 }

--- a/protocol/gpio_drive_strength_test.cc
+++ b/protocol/gpio_drive_strength_test.cc
@@ -31,5 +31,13 @@ TEST_F(LibHothTest, set_gpio_drive_strength_success) {
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
 
-  EXPECT_EQ(libhoth_set_gpio_drive_strength(&hoth_dev_, 10, 5), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_set_gpio_drive_strength(&hoth_dev_, 10, 5), HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, set_gpio_drive_strength_invalid_param) {
+  libhoth_error err = libhoth_set_gpio_drive_strength(&hoth_dev_, 10, 20);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_set_gpio_drive_strength off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.
