### PR TITLE
[protocol] Convert i2c to use the new compact error format

### DIFF
--- a/examples/htool_i2c.c
+++ b/examples/htool_i2c.c
@@ -44,9 +44,10 @@ static int i2c_detect(struct libhoth_device* dev,
   request.end_address = (uint8_t)(end_addr & 0x7F);
 
   struct hoth_response_i2c_detect response;
-  int ret = libhoth_i2c_detect(dev, &request, &response);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err = libhoth_i2c_detect(dev, &request, &response);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("i2c_detect", err);
+    return -1;
   }
 
   printf("Detected %u devices on bus.\n", response.devices_count);
@@ -96,9 +97,10 @@ static int i2c_read(struct libhoth_device* dev,
   }
 
   struct hoth_response_i2c_transfer response;
-  int ret = libhoth_i2c_transfer(dev, &request, &response);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err = libhoth_i2c_transfer(dev, &request, &response);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("i2c_transfer", err);
+    return -1;
   }
 
   if (offset != UINT32_MAX) {
@@ -167,9 +169,10 @@ static int i2c_write(struct libhoth_device* dev,
   request.size_write = idx;
 
   struct hoth_response_i2c_transfer response;
-  int ret = libhoth_i2c_transfer(dev, &request, &response);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err = libhoth_i2c_transfer(dev, &request, &response);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("i2c_transfer", err);
+    return -1;
   }
 
   if (offset != UINT32_MAX) {

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -231,6 +231,7 @@ cc_library(
     hdrs = ["i2c.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/i2c.c
+++ b/protocol/i2c.c
@@ -14,30 +14,31 @@
 
 #include "i2c.h"
 
+#include <stddef.h>
 #include <stdio.h>
 
 #include "host_cmd.h"
 
-int libhoth_i2c_detect(struct libhoth_device* dev,
-                       struct hoth_request_i2c_detect* req,
-                       struct hoth_response_i2c_detect* resp) {
+libhoth_error libhoth_i2c_detect(struct libhoth_device* dev,
+                                 struct hoth_request_i2c_detect* req,
+                                 struct hoth_response_i2c_detect* resp) {
+  if (req == NULL || resp == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   size_t rLen = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_I2C_DETECT, 0, req,
       sizeof(*req), resp, sizeof(*resp), &rLen);
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_I2C_DETECT error code: %d\n", ret);
-    return -1;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
   if (rLen != sizeof(*resp)) {
-    fprintf(stderr,
-            "HOTH_I2C_DETECT expected exactly %ld response "
-            "bytes, got %ld\n",
-            sizeof(*resp), rLen);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return ret;
+  return HOTH_SUCCESS;
 }
 
 void libhoth_i2c_device_list(uint8_t* devices_mask, uint32_t devices_count,
@@ -63,24 +64,24 @@ void libhoth_i2c_device_list(uint8_t* devices_mask, uint32_t devices_count,
   return;
 }
 
-int libhoth_i2c_transfer(struct libhoth_device* dev,
-                         struct hoth_request_i2c_transfer* req,
-                         struct hoth_response_i2c_transfer* resp) {
+libhoth_error libhoth_i2c_transfer(struct libhoth_device* dev,
+                                   struct hoth_request_i2c_transfer* req,
+                                   struct hoth_response_i2c_transfer* resp) {
+  if (req == NULL || resp == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   size_t rLen = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_I2C_TRANSFER, 0,
       req, sizeof(*req), resp, sizeof(*resp), &rLen);
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_I2C_TRANSFER error code: %d\n", ret);
-    return -1;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
   if (rLen != sizeof(*resp)) {
-    fprintf(stderr,
-            "HOTH_I2C_TRANSFER expected exactly %ld response "
-            "bytes, got %ld\n",
-            sizeof(*resp), rLen);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return ret;
+  return HOTH_SUCCESS;
 }

--- a/protocol/i2c.h
+++ b/protocol/i2c.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 /*
@@ -50,9 +51,9 @@ struct hoth_response_i2c_detect {
   uint8_t devices_mask[I2C_DETECT_DATA_MAX_SIZE_BYTES];
 } __attribute__((packed, aligned(4)));
 
-int libhoth_i2c_detect(struct libhoth_device* dev,
-                       struct hoth_request_i2c_detect* req,
-                       struct hoth_response_i2c_detect* resp);
+libhoth_error libhoth_i2c_detect(struct libhoth_device* dev,
+                                 struct hoth_request_i2c_detect* req,
+                                 struct hoth_response_i2c_detect* resp);
 
 // Converts the above devices_mask into a list of devices addresses
 // The first `devices_count` entries of `device_list` will be populated
@@ -106,9 +107,9 @@ struct hoth_response_i2c_transfer {
   uint8_t resp_bytes[I2C_TRANSFER_DATA_MAX_SIZE_BYTES];
 } __attribute__((packed, aligned(4)));
 
-int libhoth_i2c_transfer(struct libhoth_device* dev,
-                         struct hoth_request_i2c_transfer* req,
-                         struct hoth_response_i2c_transfer* resp);
+libhoth_error libhoth_i2c_transfer(struct libhoth_device* dev,
+                                   struct hoth_request_i2c_transfer* req,
+                                   struct hoth_response_i2c_transfer* resp);
 
 #ifdef __cplusplus
 }

--- a/protocol/i2c_test.cc
+++ b/protocol/i2c_test.cc
@@ -49,7 +49,7 @@ TEST_F(LibHothTest, i2c_detect_test) {
       .end_address = 0x7F,
   };
   struct hoth_response_i2c_detect resp;
-  EXPECT_EQ(libhoth_i2c_detect(&hoth_dev_, &req, &resp), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_i2c_detect(&hoth_dev_, &req, &resp), HOTH_SUCCESS);
 
   EXPECT_EQ(resp.bus_response, ex_resp.bus_response);
   EXPECT_EQ(resp.devices_count, ex_resp.devices_count);
@@ -87,7 +87,7 @@ TEST_F(LibHothTest, i2c_transfer_test) {
   };
 
   struct hoth_response_i2c_transfer resp;
-  EXPECT_EQ(libhoth_i2c_transfer(&hoth_dev_, &xfer, &resp), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_i2c_transfer(&hoth_dev_, &xfer, &resp), HOTH_SUCCESS);
 
   EXPECT_EQ(resp.bus_response, ex_resp.bus_response);
   // EXPECT_EQ does funny things with its arguments and may cause them to
@@ -95,4 +95,22 @@ TEST_F(LibHothTest, i2c_transfer_test) {
   // access, so we explicitly add casts here.
   EXPECT_EQ(static_cast<uint16_t>(resp.read_bytes),
             static_cast<uint16_t>(ex_resp.read_bytes));
+}
+
+TEST_F(LibHothTest, i2c_detect_null_param_test) {
+  struct hoth_response_i2c_detect resp;
+  libhoth_error err = libhoth_i2c_detect(&hoth_dev_, nullptr, &resp);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
+}
+
+TEST_F(LibHothTest, i2c_transfer_null_param_test) {
+  struct hoth_response_i2c_transfer resp;
+  libhoth_error err = libhoth_i2c_transfer(&hoth_dev_, nullptr, &resp);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_i2c_detect and libhoth_i2c_transfer off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.