### PR TITLE
[protocol] Convert panic to use the new compact error format

### DIFF
--- a/examples/htool_panic.c
+++ b/examples/htool_panic.c
@@ -63,13 +63,20 @@ int htool_panic_get_panic(const struct htool_invocation* inv) {
 
   if (clear) {
     printf("Clearing panic log from flash.\n");
-    return libhoth_clear_persistent_panic_info(dev);
+    libhoth_error err = libhoth_clear_persistent_panic_info(dev);
+    if (err != HOTH_SUCCESS) {
+      htool_report_error("clear_persistent_panic_info", err);
+      return -1;
+    }
+    return 0;
   }
 
   struct hoth_response_persistent_panic_info panic;
   memset(&panic, 0, sizeof(panic));
 
-  if (libhoth_get_panic(dev, &panic)) {
+  libhoth_error err = libhoth_get_panic(dev, &panic);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("get_panic", err);
     return -1;
   }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -84,6 +84,7 @@ cc_library(
     hdrs = ["panic.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/panic.c
+++ b/protocol/panic.c
@@ -14,6 +14,7 @@
 
 #include "panic.h"
 
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "host_cmd.h"
@@ -180,8 +181,14 @@ static int check_expected_response_length(uint16_t length, uint16_t expected) {
   return 0;
 }
 
-int libhoth_get_panic(struct libhoth_device* dev,
-                      struct hoth_response_persistent_panic_info* panic_data) {
+libhoth_error libhoth_get_panic(
+    struct libhoth_device* dev,
+    struct hoth_response_persistent_panic_info* panic_data) {
+  if (panic_data == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
   const uint16_t cmd =
       HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PERSISTENT_PANIC_INFO;
   uint8_t* dest = (uint8_t*)panic_data;
@@ -198,22 +205,23 @@ int libhoth_get_panic(struct libhoth_device* dev,
         .index = i,
     };
 
-    int ret = libhoth_hostcmd_exec(dev, cmd, 0, &req, sizeof(req), dest,
-                                   chunk_size, &rlen);
+    libhoth_error err = libhoth_hostcmd_exec_v2(dev, cmd, 0, &req, sizeof(req),
+                                                dest, chunk_size, &rlen);
 
-    if (ret) {
-      return -1;
+    if (err != HOTH_SUCCESS) {
+      return err;
     }
 
     if (check_expected_response_length(rlen, chunk_size)) {
-      return -1;
+      return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                   LIBHOTH_ERR_FAIL);
     }
   }
 
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_clear_persistent_panic_info(struct libhoth_device* dev) {
+libhoth_error libhoth_clear_persistent_panic_info(struct libhoth_device* dev) {
   size_t rlen;
 
   struct hoth_request_persistent_panic_info req = {
@@ -222,15 +230,19 @@ int libhoth_clear_persistent_panic_info(struct libhoth_device* dev) {
   const uint16_t cmd =
       HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PERSISTENT_PANIC_INFO;
 
-  if (libhoth_hostcmd_exec(dev, cmd, 0, &req, sizeof(req), NULL, 0, &rlen)) {
-    return -1;
+  libhoth_error err =
+      libhoth_hostcmd_exec_v2(dev, cmd, 0, &req, sizeof(req), NULL, 0, &rlen);
+
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
 
   if (check_expected_response_length(rlen, 0)) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return 0;
+  return HOTH_SUCCESS;
 }
 
 void libhoth_print_panic_info(

--- a/protocol/panic.h
+++ b/protocol/panic.h
@@ -22,6 +22,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #define HOTH_PRV_CMD_HOTH_PERSISTENT_PANIC_INFO 0x0014
@@ -132,9 +133,10 @@ enum panic_arch {
 /* Already reported via host event */
 #define PANIC_DATA_FLAG_OLD_HOSTEVENT (1 << 3)
 
-int libhoth_get_panic(struct libhoth_device* dev,
-                      struct hoth_response_persistent_panic_info* panic_data);
-int libhoth_clear_persistent_panic_info(struct libhoth_device* dev);
+libhoth_error libhoth_get_panic(
+    struct libhoth_device* dev,
+    struct hoth_response_persistent_panic_info* panic_data);
+libhoth_error libhoth_clear_persistent_panic_info(struct libhoth_device* dev);
 void libhoth_print_panic_info(
     const struct hoth_response_persistent_panic_info* panic);
 

--- a/protocol/panic_test.cc
+++ b/protocol/panic_test.cc
@@ -85,7 +85,7 @@ TEST_F(LibHothTest, panic_test) {
   }
 
   struct hoth_response_persistent_panic_info panic_record;
-  EXPECT_EQ(libhoth_get_panic(&hoth_dev_, &panic_record), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_get_panic(&hoth_dev_, &panic_record), HOTH_SUCCESS);
 
   EXPECT_EQ(exp_panic_record.rw_version.epoch, panic_record.rw_version.epoch);
   EXPECT_EQ(exp_panic_record.rw_version.major, panic_record.rw_version.major);
@@ -104,5 +104,13 @@ TEST_F(LibHothTest, clear_panic_test) {
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
 
-  EXPECT_EQ(libhoth_clear_persistent_panic_info(&hoth_dev_), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_clear_persistent_panic_info(&hoth_dev_), HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, panic_null_param_test) {
+  libhoth_error err = libhoth_get_panic(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_get_panic and libhoth_clear_persistent_panic_info off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.