### PR TITLE
[protocol] Convert payload_status to use the new compact error format

### DIFF
--- a/examples/htool_payload.c
+++ b/examples/htool_payload.c
@@ -151,9 +151,9 @@ int htool_payload_status(const struct htool_invocation* inv) {
   }
 
   struct payload_status ps;
-  int ret = libhoth_payload_status(dev, &ps);
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_PAYLOAD_STATUS error code: %d\n", ret);
+  libhoth_error err = libhoth_payload_status(dev, &ps);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("payload_status", err);
     return -1;
   }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -61,6 +61,7 @@ cc_library(
     hdrs = ["payload_status.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/payload_status.c
+++ b/protocol/payload_status.c
@@ -18,15 +18,20 @@
 
 #include "host_cmd.h"
 
-int libhoth_payload_status(struct libhoth_device* dev,
-                           struct payload_status* payload_status) {
+libhoth_error libhoth_payload_status(struct libhoth_device* dev,
+                                     struct payload_status* payload_status) {
+  if (payload_status == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
   size_t rlen = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_PAYLOAD_STATUS, 0,
       NULL, 0, payload_status, sizeof(*payload_status), &rlen);
 
-  if (ret != 0) {
-    return ret;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
 
   size_t expected_rlen = sizeof(struct payload_status_response_header) +
@@ -34,10 +39,11 @@ int libhoth_payload_status(struct libhoth_device* dev,
                              sizeof(struct payload_region_state);
 
   if (rlen != expected_rlen) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return ret;
+  return HOTH_SUCCESS;
 }
 
 const char* libhoth_sps_eeprom_lockdown_status_string(uint8_t st) {

--- a/protocol/payload_status.h
+++ b/protocol/payload_status.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -64,8 +65,8 @@ const char* libhoth_payload_validation_state_string(uint8_t s);
 const char* libhoth_payload_validation_failure_reason_string(uint8_t r);
 const char* libhoth_image_type_string(uint8_t type);
 
-int libhoth_payload_status(struct libhoth_device* dev,
-                           struct payload_status* payload_state);
+libhoth_error libhoth_payload_status(struct libhoth_device* dev,
+                                     struct payload_status* payload_state);
 
 #ifdef __cplusplus
 }

--- a/protocol/payload_status_test.cc
+++ b/protocol/payload_status_test.cc
@@ -74,7 +74,7 @@ TEST_F(LibHothTest, payload_status_test) {
                 Return(LIBHOTH_OK)));
 
   struct payload_status status;
-  EXPECT_EQ(libhoth_payload_status(&hoth_dev_, &status), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_payload_status(&hoth_dev_, &status), HOTH_SUCCESS);
 
   EXPECT_TRUE(std::memcmp(&kDefaultPayloadStatus, &status, sizeof(status)) ==
               0);
@@ -95,7 +95,15 @@ TEST_F(LibHothTest, payload_status_bad_region_count) {
           DoAll(CopyResp(&bad_status, sizeof(bad_status)), Return(LIBHOTH_OK)));
 
   struct payload_status status;
-  EXPECT_EQ(libhoth_payload_status(&hoth_dev_, &status), -1);
+  EXPECT_NE(libhoth_payload_status(&hoth_dev_, &status), HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, payload_status_null_param_test) {
+  libhoth_error err = libhoth_payload_status(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 TEST_F(LibHothTest, lockdown_status_string) {


### PR DESCRIPTION
Migrates libhoth_payload_status off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.