### PR TITLE
[protocol] Convert reboot to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -108,7 +108,13 @@ static int command_reboot(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return libhoth_reboot(dev, warm ? HOTH_REBOOT_WARM : HOTH_REBOOT_COLD);
+  libhoth_error err =
+      libhoth_reboot(dev, warm ? HOTH_REBOOT_WARM : HOTH_REBOOT_COLD);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("reboot", err);
+    return -1;
+  }
+  return 0;
 }
 
 static int command_get_version(const struct htool_invocation* inv) {

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -164,6 +164,7 @@ cc_library(
     hdrs = ["reboot.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/reboot.c
+++ b/protocol/reboot.c
@@ -14,12 +14,15 @@
 
 #include "reboot.h"
 
+#include <stddef.h>
+
 #include "host_cmd.h"
 
-int libhoth_reboot(struct libhoth_device* dev, enum hoth_reboot_cmd cmd) {
+libhoth_error libhoth_reboot(struct libhoth_device* dev,
+                             enum hoth_reboot_cmd cmd) {
   struct hoth_params_reboot_ec req = {
       .cmd = cmd,
   };
-  return libhoth_hostcmd_exec(dev, HOTH_CMD_REBOOT_EC, 0, &req, sizeof(req),
-                              NULL, 0, NULL);
+  return libhoth_hostcmd_exec_v2(dev, HOTH_CMD_REBOOT_EC, 0, &req, sizeof(req),
+                                 NULL, 0, NULL);
 }

--- a/protocol/reboot.h
+++ b/protocol/reboot.h
@@ -21,7 +21,8 @@ extern "C" {
 
 #include <stdint.h>
 
-#include "host_cmd.h"
+#include "protocol/host_cmd.h"
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #define HOTH_CMD_REBOOT_EC 0x00D2
@@ -38,7 +39,8 @@ struct hoth_params_reboot_ec {
   uint8_t flags;
 } __hoth_align1;
 
-int libhoth_reboot(struct libhoth_device* dev, enum hoth_reboot_cmd cmd);
+libhoth_error libhoth_reboot(struct libhoth_device* dev,
+                             enum hoth_reboot_cmd cmd);
 
 #ifdef __cplusplus
 }

--- a/protocol/reboot_test.cc
+++ b/protocol/reboot_test.cc
@@ -31,5 +31,5 @@ TEST_F(LibHothTest, reboot_test) {
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
 
-  EXPECT_EQ(libhoth_reboot(&hoth_dev_, HOTH_REBOOT_COLD), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_reboot(&hoth_dev_, HOTH_REBOOT_COLD), HOTH_SUCCESS);
 }


### PR DESCRIPTION
Migrates libhoth_reboot off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.