### PR TITLE
[protocol] Convert rot_firmware_version to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -118,9 +118,10 @@ static int command_get_version(const struct htool_invocation* inv) {
   }
 
   struct hoth_response_get_version response;
-  int status = libhoth_get_rot_fw_version(dev, &response);
+  libhoth_error err = libhoth_get_rot_fw_version(dev, &response);
 
-  if (status) {
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("get_rot_fw_version", err);
     return -1;
   }
   printf("version_string_ro: %.*s\n", (int)sizeof(response.version_string_ro),

--- a/examples/htool_security_info.c
+++ b/examples/htool_security_info.c
@@ -48,11 +48,12 @@ int htool_info(const struct htool_invocation* inv) {
         }
 
         struct hoth_response_get_version fw_version_struct;
-        status = libhoth_get_rot_fw_version(dev, &fw_version_struct);
+        libhoth_error err = libhoth_get_rot_fw_version(dev, &fw_version_struct);
         memcpy(&fw_minor_version, &fw_version_struct.version_string_rw,
                sizeof(fw_version_struct.version_string_rw));
-        if (status != 0) {
-          return status;
+        if (err != HOTH_SUCCESS) {
+          htool_report_error("get_rot_fw_version", err);
+          return -1;
         }
         break;
       }

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -38,6 +38,7 @@ cc_library(
     hdrs = ["rot_firmware_version.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/rot_firmware_version.c
+++ b/protocol/rot_firmware_version.c
@@ -14,9 +14,15 @@
 
 #include "rot_firmware_version.h"
 
-int libhoth_get_rot_fw_version(struct libhoth_device* dev,
-                               struct hoth_response_get_version* ver) {
-  return libhoth_hostcmd_exec(dev, HOTH_CMD_GET_VERSION, /*version=*/0,
-                              /*req_payload=*/NULL, /*req_payload_size=*/0, ver,
-                              sizeof(*ver), /*out_resp_size=*/NULL);
+#include <stddef.h>
+
+libhoth_error libhoth_get_rot_fw_version(
+    struct libhoth_device* dev, struct hoth_response_get_version* ver) {
+  if (ver == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+  return libhoth_hostcmd_exec_v2(dev, HOTH_CMD_GET_VERSION, /*version=*/0,
+                                 /*req_payload=*/NULL, /*req_payload_size=*/0,
+                                 ver, sizeof(*ver), /*out_resp_size=*/NULL);
 }

--- a/protocol/rot_firmware_version.h
+++ b/protocol/rot_firmware_version.h
@@ -15,7 +15,8 @@
 #ifndef _LIBHOTH_PROTOCOL_ROT_FIRMWARE_VERSION_H_
 #define _LIBHOTH_PROTOCOL_ROT_FIRMWARE_VERSION_H_
 
-#include "host_cmd.h"
+#include "protocol/host_cmd.h"
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -37,8 +38,8 @@ struct hoth_response_get_version {
   uint32_t current_image;
 } __hoth_align4;
 
-int libhoth_get_rot_fw_version(struct libhoth_device* dev,
-                               struct hoth_response_get_version* ver);
+libhoth_error libhoth_get_rot_fw_version(struct libhoth_device* dev,
+                                         struct hoth_response_get_version* ver);
 
 #ifdef __cplusplus
 }

--- a/protocol/rot_firmware_version_test.cc
+++ b/protocol/rot_firmware_version_test.cc
@@ -38,9 +38,17 @@ TEST_F(LibHothTest, firmware_version_test) {
       .WillOnce(DoAll(CopyResp(&exp_ver, sizeof(exp_ver)), Return(LIBHOTH_OK)));
 
   struct hoth_response_get_version ver;
-  EXPECT_EQ(libhoth_get_rot_fw_version(&hoth_dev_, &ver), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_get_rot_fw_version(&hoth_dev_, &ver), HOTH_SUCCESS);
 
   ASSERT_THAT(exp_ver.version_string_ro, StrEq(ver.version_string_ro));
   ASSERT_THAT(exp_ver.version_string_rw, StrEq(ver.version_string_rw));
   EXPECT_EQ(exp_ver.current_image, ver.current_image);
+}
+
+TEST_F(LibHothTest, firmware_version_null_param_test) {
+  libhoth_error err = libhoth_get_rot_fw_version(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_get_rot_fw_version off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.