### PR TITLE
[protocol] Convert secure_boot to use the new compact error format

### DIFF
--- a/examples/htool_secure_boot.c
+++ b/examples/htool_secure_boot.c
@@ -28,10 +28,10 @@ int htool_secure_boot_get_enforcement(const struct htool_invocation* inv) {
   }
   enum secure_boot_enforcement_status enforcement =
       SECURE_BOOT_ENFORCEMENT_DISABLED;
-  int ret = libhoth_secure_boot_get_enforcement(dev, &enforcement);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to get secure boot enforcement: %d\n", ret);
-    return ret;
+  libhoth_error err = libhoth_secure_boot_get_enforcement(dev, &enforcement);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("secure_boot_get_enforcement", err);
+    return -1;
   }
   printf(
       "Secure boot enforcement: %s\n",
@@ -44,10 +44,10 @@ int htool_secure_boot_enable_enforcement(const struct htool_invocation* inv) {
   if (dev == NULL) {
     return -1;
   }
-  int ret = libhoth_secure_boot_enable_enforcement(dev);
-  if (ret) {
-    fprintf(stderr, "Failed to enable secure boot enforcement: %d\n", ret);
-    return ret;
+  libhoth_error err = libhoth_secure_boot_enable_enforcement(dev);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("secure_boot_enable_enforcement", err);
+    return -1;
   }
   printf("Secure boot enforcement enabled\n");
   return 0;

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -495,6 +495,7 @@ cc_library(
     hdrs = ["secure_boot.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/secure_boot.c
+++ b/protocol/secure_boot.c
@@ -20,37 +20,40 @@
 #include "protocol/host_cmd.h"
 #include "transports/libhoth_device.h"
 
-int libhoth_secure_boot_get_enforcement(
+libhoth_error libhoth_secure_boot_get_enforcement(
     struct libhoth_device* dev,
     enum secure_boot_enforcement_status* enforcement) {
+  if (enforcement == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
+
   struct secure_boot_enforcement_state response;
   size_t rlen = 0;
-  int ret =
-      libhoth_hostcmd_exec(dev,
-                           HOTH_CMD_BOARD_SPECIFIC_BASE +
-                               HOTH_PRV_CMD_HOTH_GET_SECURE_BOOT_ENFORCEMENT,
-                           0, NULL, 0, &response, sizeof(response), &rlen);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err =
+      libhoth_hostcmd_exec_v2(dev,
+                              HOTH_CMD_BOARD_SPECIFIC_BASE +
+                                  HOTH_PRV_CMD_HOTH_GET_SECURE_BOOT_ENFORCEMENT,
+                              0, NULL, 0, &response, sizeof(response), &rlen);
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
   if (rlen != sizeof(response)) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
   *enforcement = response.enabled;
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_secure_boot_enable_enforcement(struct libhoth_device* dev) {
+libhoth_error libhoth_secure_boot_enable_enforcement(
+    struct libhoth_device* dev) {
   struct secure_boot_enforcement_state request = {
       .enabled = SECURE_BOOT_ENFORCEMENT_ENABLED};
   size_t rlen = 0;
-  int ret =
-      libhoth_hostcmd_exec(dev,
-                           HOTH_CMD_BOARD_SPECIFIC_BASE +
-                               HOTH_PRV_CMD_HOTH_SET_SECURE_BOOT_ENFORCEMENT,
-                           0, &request, sizeof(request), NULL, 0, &rlen);
-  if (ret != 0) {
-    return ret;
-  }
-  return 0;
+  return libhoth_hostcmd_exec_v2(
+      dev,
+      HOTH_CMD_BOARD_SPECIFIC_BASE +
+          HOTH_PRV_CMD_HOTH_SET_SECURE_BOOT_ENFORCEMENT,
+      0, &request, sizeof(request), NULL, 0, &rlen);
 }

--- a/protocol/secure_boot.h
+++ b/protocol/secure_boot.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -37,13 +38,14 @@ struct secure_boot_enforcement_state {
 } __attribute__((packed));
 
 // Get the current state of target secure boot enforcement.
-int libhoth_secure_boot_get_enforcement(
+libhoth_error libhoth_secure_boot_get_enforcement(
     struct libhoth_device* dev,
     enum secure_boot_enforcement_status* enforcement);
 
 // Enable secure boot enforcement. Disabling is done via a different,
 // authorized, command.
-int libhoth_secure_boot_enable_enforcement(struct libhoth_device* dev);
+libhoth_error libhoth_secure_boot_enable_enforcement(
+    struct libhoth_device* dev);
 
 #ifdef __cplusplus
 }

--- a/protocol/secure_boot_test.cc
+++ b/protocol/secure_boot_test.cc
@@ -43,7 +43,8 @@ TEST_F(LibHothTest, GetSecureBootEnforcementSuccess) {
   enum secure_boot_enforcement_status actual_enforcement =
       SECURE_BOOT_ENFORCEMENT_DISABLED;
   EXPECT_EQ(
-      libhoth_secure_boot_get_enforcement(&hoth_dev_, &actual_enforcement), 0);
+      libhoth_secure_boot_get_enforcement(&hoth_dev_, &actual_enforcement),
+      HOTH_SUCCESS);
   EXPECT_EQ(actual_enforcement, expected_enforcement.enabled);
 }
 
@@ -57,7 +58,15 @@ TEST_F(LibHothTest, EnableSecureBootEnforcementSuccess) {
   uint32_t dummy;
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
-  EXPECT_EQ(libhoth_secure_boot_enable_enforcement(&hoth_dev_), 0);
+  EXPECT_EQ(libhoth_secure_boot_enable_enforcement(&hoth_dev_), HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, GetSecureBootEnforcementNullParam) {
+  libhoth_error err = libhoth_secure_boot_get_enforcement(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 }  // namespace


### PR DESCRIPTION
Migrates libhoth_secure_boot_get_enforcement and
libhoth_secure_boot_enable_enforcement off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.