### PR TITLE
[protocol] Convert statistics to use the new compact error format

### DIFF
--- a/examples/htool_statistics.c
+++ b/examples/htool_statistics.c
@@ -186,9 +186,9 @@ int htool_statistics(const struct htool_invocation* inv) {
   }
 
   struct hoth_response_statistics stat;
-  int ret = libhoth_get_statistics(dev, &stat);
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_STATISTICS error code: %d\n", ret);
+  libhoth_error err = libhoth_get_statistics(dev, &stat);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("get_statistics", err);
     return -1;
   }
 

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -140,6 +140,7 @@ cc_library(
     hdrs = ["statistics.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/statistics.c
+++ b/protocol/statistics.c
@@ -14,12 +14,18 @@
 
 #include "statistics.h"
 
+#include <stddef.h>
+
 #include "host_cmd.h"
 
-int libhoth_get_statistics(struct libhoth_device* dev,
-                           struct hoth_response_statistics* stats) {
+libhoth_error libhoth_get_statistics(struct libhoth_device* dev,
+                                     struct hoth_response_statistics* stats) {
+  if (stats == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   size_t rlen = 0;
-  return libhoth_hostcmd_exec(
+  return libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_GET_STATISTICS, 0,
       NULL, 0, stats, sizeof(*stats), &rlen);
 }

--- a/protocol/statistics.h
+++ b/protocol/statistics.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 /* Get various statistics */
@@ -129,8 +130,8 @@ struct hoth_response_statistics {
   uint32_t reserved[42];
 } __attribute__((packed));
 
-int libhoth_get_statistics(struct libhoth_device* dev,
-                           struct hoth_response_statistics* stats);
+libhoth_error libhoth_get_statistics(struct libhoth_device* dev,
+                                     struct hoth_response_statistics* stats);
 
 #ifdef __cplusplus
 }

--- a/protocol/statistics_test.cc
+++ b/protocol/statistics_test.cc
@@ -42,9 +42,17 @@ TEST_F(LibHothTest, statistics_test) {
           DoAll(CopyResp(&exp_stat, sizeof(exp_stat)), Return(LIBHOTH_OK)));
 
   struct hoth_response_statistics stat = {};
-  EXPECT_EQ(libhoth_get_statistics(&hoth_dev_, &stat), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_get_statistics(&hoth_dev_, &stat), HOTH_SUCCESS);
 
   EXPECT_EQ(exp_stat.valid_words, stat.valid_words);
   EXPECT_EQ(exp_stat.time_since_hoth_boot_us, stat.time_since_hoth_boot_us);
   EXPECT_EQ(exp_stat.scratch_value, stat.scratch_value);
+}
+
+TEST_F(LibHothTest, statistics_null_param_test) {
+  libhoth_error err = libhoth_get_statistics(&hoth_dev_, nullptr);
+  EXPECT_NE(err, HOTH_SUCCESS);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
Migrates libhoth_get_statistics off the legacy integer return type onto libhoth_error and libhoth_hostcmd_exec_v2.