### PR TITLE
[protocol] Convert authz_record to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -211,9 +211,10 @@ static int command_authz_record_read(const struct htool_invocation* inv) {
   }
 
   struct hoth_authz_record_get_response response;
-  int status = libhoth_authz_record_read(dev, &response);
-  if (status != 0) {
-    return status;
+  libhoth_error err = libhoth_authz_record_read(dev, &response);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("authz_record_read", err);
+    return -1;
   }
 
   printf("Index: %d \n", response.index);
@@ -229,7 +230,12 @@ static int command_authz_record_erase(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return libhoth_authz_record_erase(dev);
+  libhoth_error err = libhoth_authz_record_erase(dev);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("authz_record_erase", err);
+    return -1;
+  }
+  return 0;
 }
 
 static int command_authz_record_build(const struct htool_invocation* inv) {
@@ -244,9 +250,10 @@ static int command_authz_record_build(const struct htool_invocation* inv) {
   }
 
   struct authorization_record record;
-  int status = libhoth_authz_record_build(dev, caps, &record);
-  if (status != 0) {
-    return status;
+  libhoth_error err = libhoth_authz_record_build(dev, caps, &record);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("authz_record_build", err);
+    return -1;
   }
 
   printf("Record:\n");
@@ -273,7 +280,12 @@ static int command_authz_record_set(const struct htool_invocation* inv) {
     return -1;
   }
 
-  return libhoth_authz_record_set(dev, &record);
+  libhoth_error err = libhoth_authz_record_set(dev, &record);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("authz_record_set", err);
+    return -1;
+  }
+  return 0;
 }
 
 static int command_authz_host_command_build(

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -256,6 +256,7 @@ cc_library(
     deps = [
         ":chipinfo",
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )

--- a/protocol/authz_record.c
+++ b/protocol/authz_record.c
@@ -14,32 +14,42 @@
 
 #include "authz_record.h"
 
+#include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "chipinfo.h"
 
-int libhoth_authz_record_erase(struct libhoth_device* dev) {
+libhoth_error libhoth_authz_record_erase(struct libhoth_device* dev) {
   struct hoth_authz_record_set_request request = {
       .index = 0,
       .erase = 1,
   };
-  return libhoth_hostcmd_exec(
+  return libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_SET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
 }
 
-int libhoth_authz_record_read(struct libhoth_device* dev,
-                              struct hoth_authz_record_get_response* resp) {
+libhoth_error libhoth_authz_record_read(
+    struct libhoth_device* dev, struct hoth_authz_record_get_response* resp) {
+  if (resp == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   struct hoth_authz_record_get_request request = {.index = 0};
-  return libhoth_hostcmd_exec(
+  return libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_GET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), resp, sizeof(*resp), NULL);
 }
 
-int libhoth_authz_record_build(struct libhoth_device* dev,
-                               uint32_t capabilities,
-                               struct authorization_record* record) {
+libhoth_error libhoth_authz_record_build(struct libhoth_device* dev,
+                                         uint32_t capabilities,
+                                         struct authorization_record* record) {
+  if (record == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   memset(record, 0, sizeof(*record));
   memcpy(&record->magic, AUTHORIZATION_RECORD_MAGIC, sizeof(record->magic));
   record->version = 1;
@@ -51,7 +61,8 @@ int libhoth_authz_record_build(struct libhoth_device* dev,
   struct hoth_response_chip_info chipinfo_resp;
   int status = libhoth_chipinfo(dev, &chipinfo_resp);
   if (status != 0) {
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 status);
   }
   if (chipinfo_resp.version != 0) {
     fprintf(stderr, "Unsupported chipinfo version: %u\n",
@@ -64,24 +75,26 @@ int libhoth_authz_record_build(struct libhoth_device* dev,
       (chipinfo_resp.data.hoth_device_id.hardware_identity >> 32);
 
   struct hoth_authz_record_get_nonce_response nonce_resp;
-  status = libhoth_hostcmd_exec(
+  libhoth_error err = libhoth_hostcmd_exec_v2(
       dev,
       HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_GET_AUTHZ_RECORD_NONCE,
       /*version=*/0, NULL, 0, &nonce_resp, sizeof(nonce_resp), NULL);
-  if (status != 0) {
-    return status;
+  if (err != HOTH_SUCCESS) {
+    return err;
   }
   if (nonce_resp.ro_supported_key_id == 0) {
     fprintf(stderr,
             "ro_supported_key_id = 0. Please reset the chip and retry\n");
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
   if (nonce_resp.ro_supported_key_id != nonce_resp.rw_supported_key_id) {
     fprintf(
         stderr,
         "RO and RW supported key_ids do not match: (RO) 0x%x != (RW) 0x%x\n",
         nonce_resp.ro_supported_key_id, nonce_resp.rw_supported_key_id);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
   record->key_id = nonce_resp.ro_supported_key_id;
   if (sizeof(record->authorization_nonce) !=
@@ -89,16 +102,21 @@ int libhoth_authz_record_build(struct libhoth_device* dev,
     fprintf(stderr, "Nonce size does not match. Expecting %ld, got %ld",
             sizeof(nonce_resp.authorization_nonce),
             sizeof(record->authorization_nonce));
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
   memcpy(record->authorization_nonce, nonce_resp.authorization_nonce,
          sizeof(record->authorization_nonce));
 
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_authz_record_set(struct libhoth_device* dev,
-                             const struct authorization_record* record) {
+libhoth_error libhoth_authz_record_set(
+    struct libhoth_device* dev, const struct authorization_record* record) {
+  if (record == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   struct hoth_authz_record_set_request request = {
       .index = 0,
       .erase = 0,
@@ -106,7 +124,7 @@ int libhoth_authz_record_set(struct libhoth_device* dev,
 
   memcpy(&request.record, record, sizeof(struct authorization_record));
 
-  return libhoth_hostcmd_exec(
+  return libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_SET_AUTHZ_RECORD,
       /*version=*/0, &request, sizeof(request), NULL, 0, NULL);
 }

--- a/protocol/authz_record.h
+++ b/protocol/authz_record.h
@@ -17,7 +17,8 @@
 
 #include <assert.h>
 
-#include "host_cmd.h"
+#include "protocol/host_cmd.h"
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -107,14 +108,14 @@ struct hoth_authz_record_get_nonce_response {
   uint32_t rw_supported_key_id;
 } __attribute__((packed));
 
-int libhoth_authz_record_erase(struct libhoth_device* dev);
-int libhoth_authz_record_read(struct libhoth_device* dev,
-                              struct hoth_authz_record_get_response* resp);
-int libhoth_authz_record_build(struct libhoth_device* dev,
-                               uint32_t capabilities,
-                               struct authorization_record* record);
-int libhoth_authz_record_set(struct libhoth_device* dev,
-                             const struct authorization_record* record);
+libhoth_error libhoth_authz_record_erase(struct libhoth_device* dev);
+libhoth_error libhoth_authz_record_read(
+    struct libhoth_device* dev, struct hoth_authz_record_get_response* resp);
+libhoth_error libhoth_authz_record_build(struct libhoth_device* dev,
+                                         uint32_t capabilities,
+                                         struct authorization_record* record);
+libhoth_error libhoth_authz_record_set(
+    struct libhoth_device* dev, const struct authorization_record* record);
 
 int libhoth_authorization_record_print_hex_string(
     const struct authorization_record* record);

--- a/protocol/authz_record_test.cc
+++ b/protocol/authz_record_test.cc
@@ -37,7 +37,7 @@ TEST_F(LibHothTest, authz_erase_test) {
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
 
-  EXPECT_EQ(libhoth_authz_record_erase(&hoth_dev_), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_authz_record_erase(&hoth_dev_), HOTH_SUCCESS);
 
   EXPECT_CALL(mock_, send(_,
                           UsesCommand(HOTH_CMD_BOARD_SPECIFIC_BASE +
@@ -45,9 +45,12 @@ TEST_F(LibHothTest, authz_erase_test) {
                           _))
       .WillOnce(Return(LIBHOTH_OK));
 
-  EXPECT_CALL(mock_, receive).WillOnce(DoAll(CopyResp(&dummy, 0), Return(-1)));
+  EXPECT_CALL(mock_, receive)
+      .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_ERR_TIMEOUT)));
 
-  EXPECT_EQ(libhoth_authz_record_erase(&hoth_dev_), -1);
+  EXPECT_EQ(libhoth_authz_record_erase(&hoth_dev_),
+            LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                  LIBHOTH_ERR_TIMEOUT));
 }
 
 TEST_F(LibHothTest, authz_read_test) {
@@ -67,7 +70,7 @@ TEST_F(LibHothTest, authz_read_test) {
       .WillOnce(DoAll(CopyResp(&resp, sizeof(resp)), Return(LIBHOTH_OK)));
 
   struct hoth_authz_record_get_response act_resp;
-  EXPECT_EQ(libhoth_authz_record_read(&hoth_dev_, &act_resp), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_authz_record_read(&hoth_dev_, &act_resp), HOTH_SUCCESS);
   EXPECT_EQ(resp.index, act_resp.index);
   EXPECT_EQ(resp.valid, act_resp.valid);
   EXPECT_EQ(resp.valid, act_resp.valid);
@@ -105,7 +108,7 @@ TEST_F(LibHothTest, authz_build_test) {
   uint32_t cap = 123;
   struct authorization_record record = {};
 
-  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record), HOTH_SUCCESS);
   EXPECT_EQ(record.version, 1);
   EXPECT_EQ(record.flags, 0);
   EXPECT_EQ(*(uint32_t*)record.capabilities, cap);
@@ -147,7 +150,9 @@ TEST_F(LibHothTest, authz_build_fail_test) {
   uint32_t cap = 123;
   struct authorization_record record = {};
 
-  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record), -1);
+  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record),
+            LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                  LIBHOTH_ERR_FAIL));
 }
 
 TEST_F(LibHothTest, authz_mismatch_key_id_test) {
@@ -183,7 +188,9 @@ TEST_F(LibHothTest, authz_mismatch_key_id_test) {
   uint32_t cap = 123;
   struct authorization_record record = {};
 
-  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record), -1);
+  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record),
+            LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                  LIBHOTH_ERR_FAIL));
 }
 
 TEST_F(LibHothTest, authz_nonce_fail_test) {
@@ -215,7 +222,9 @@ TEST_F(LibHothTest, authz_nonce_fail_test) {
   uint32_t cap = 123;
   struct authorization_record record;
 
-  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record), -1);
+  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, cap, &record),
+            LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                  LIBHOTH_ERR_FAIL));
 }
 
 TEST_F(LibHothTest, authz_set_test) {
@@ -230,5 +239,15 @@ TEST_F(LibHothTest, authz_set_test) {
       .WillOnce(DoAll(CopyResp(&dummy, 0), Return(LIBHOTH_OK)));
 
   struct authorization_record record = {};
-  EXPECT_EQ(libhoth_authz_record_set(&hoth_dev_, &record), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_authz_record_set(&hoth_dev_, &record), HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, authz_null_param_test) {
+  libhoth_error expected_param_err =
+      LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                            LIBHOTH_ERR_INVALID_PARAMETER);
+  EXPECT_EQ(libhoth_authz_record_read(&hoth_dev_, nullptr), expected_param_err);
+  EXPECT_EQ(libhoth_authz_record_build(&hoth_dev_, 123, nullptr),
+            expected_param_err);
+  EXPECT_EQ(libhoth_authz_record_set(&hoth_dev_, nullptr), expected_param_err);
 }


### PR DESCRIPTION
Migrates libhoth_authz_record_erase, libhoth_authz_record_read, libhoth_authz_record_build, and libhoth_authz_record_set off the legacy integer return type onto libhoth_error and
libhoth_hostcmd_exec_v2