### PR TITLE
Disable fully_static_link for htool on 32-bit platforms

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -239,6 +239,7 @@ cc_binary(
         "htool_usb.c",
         "htool_usb.h",
     ],
+    features = ["-fully_static_link"],
     deps = [
         ":host_commands",
         ":srtm",


### PR DESCRIPTION
Building htool for 32-bit ARM (armv7a and armv7ahf) fails during release builds because the OpenBMC toolchain does not contain static standard libraries (libc.a, librt.a, etc.). Disabling the fully_static_link feature for this cc_binary target allows it to fall back to dynamic linking, resolving the compilation failure.