### PR TITLE
defense-in-depth improvements to GitHub actions workflows

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -1,13 +1,18 @@
 name: Check clang-format
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   formatting-check:
     name: Formatting Check
     runs-on: 'ubuntu-24.04'
+
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.17.0
+      uses: jidicula/clang-format-action@654a770daa28443dd111d133e4083e21c1075674 # v4.18.0
       with:
         clang-format-version: '21'
         fallback-style: 'Google' # optional

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Run clang-format style check for C/C++/Protobuf programs.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -23,7 +26,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install extra packages
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
these are defense-in-depth improvements on your CI workflows:

- actions refs are pinned by hash instead of by floating version tags
- git credentials (containing the `GITHUB_TOKEN`) are not persisted in the local workspace when the code is checked out
- default read-only permissions are codified at the top level of the workflows, adhering to the principle of least privilege 

it would be good to also configure dependabot to keep these actions up to date, but I can do that in a separate PR if you'd like.