### PR TITLE
Update htool to use fully_static_link_target

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -239,7 +239,7 @@ cc_binary(
         "htool_usb.c",
         "htool_usb.h",
     ],
-    features = ["-fully_static_link"],
+    features = ["fully_static_link_target"],
     deps = [
         ":host_commands",
         ":srtm",


### PR DESCRIPTION
This change replaces the deprecated fully_static_link feature with
fully_static_link_target in htool.blueprint. This aligns with
updated toolchain features for static linking.