### PR TITLE
[protocol] Convert jtag to use the new compact error format

### DIFF
--- a/examples/htool_jtag.c
+++ b/examples/htool_jtag.c
@@ -58,9 +58,11 @@ static int jtag_read_idcode(struct libhoth_device* dev,
   }
 
   uint32_t idcode = 0;
-  int ret = libhoth_jtag_read_idcode(dev, interface_id, clk_idiv, &idcode);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err =
+      libhoth_jtag_read_idcode(dev, interface_id, clk_idiv, &idcode);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("jtag read_idcode", err);
+    return -1;
   }
 
   printf("IDCODE: 0x%08x\n", idcode);
@@ -150,10 +152,11 @@ static int jtag_test_bypass(struct libhoth_device* dev,
   printf("\n");
 
   uint8_t tdo_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN] = {0};
-  ret = libhoth_jtag_test_bypass(dev, interface_id, clk_idiv, tdi_bytes,
-                                 tdo_bytes);
-  if (ret != 0) {
-    return ret;
+  libhoth_error err = libhoth_jtag_test_bypass(dev, interface_id, clk_idiv,
+                                               tdi_bytes, tdo_bytes);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("jtag test_bypass", err);
+    return -1;
   }
 
   bool tdo_matches_tdi = true;
@@ -188,7 +191,13 @@ static int jtag_program_and_verify_pld(struct libhoth_device* dev,
     return -1;
   }
 
-  return libhoth_jtag_program_and_verify_pld(dev, interface_id, offset);
+  libhoth_error err =
+      libhoth_jtag_program_and_verify_pld(dev, interface_id, offset);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("jtag program_and_verify_pld", err);
+    return -1;
+  }
+  return 0;
 }
 
 static int jtag_verify_pld(struct libhoth_device* dev,
@@ -208,7 +217,12 @@ static int jtag_verify_pld(struct libhoth_device* dev,
     return -1;
   }
 
-  return libhoth_jtag_verify_pld(dev, interface_id, offset);
+  libhoth_error err = libhoth_jtag_verify_pld(dev, interface_id, offset);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("jtag verify_pld", err);
+    return -1;
+  }
+  return 0;
 }
 
 int htool_jtag_run(const struct htool_invocation* inv) {

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -401,6 +401,7 @@ cc_library(
     hdrs = ["jtag.h"],
     deps = [
         ":host_cmd",
+        ":libhoth_status",
         "//transports:libhoth_device",
     ],
 )
@@ -410,6 +411,7 @@ cc_test(
     srcs = ["jtag_test.cc"],
     deps = [
         ":jtag",
+        ":libhoth_status",
         "//protocol/test:libhoth_device_mock",
         "//transports:libhoth_device",
         "@googletest//:gtest",

--- a/protocol/jtag.c
+++ b/protocol/jtag.c
@@ -12,17 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "jtag.h"
+#include "protocol/jtag.h"
 
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "host_cmd.h"
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
-int libhoth_jtag_read_idcode(struct libhoth_device* dev, uint8_t interface_id,
-                             uint16_t clk_idiv, uint32_t* idcode) {
+libhoth_error libhoth_jtag_read_idcode(struct libhoth_device* dev,
+                                       uint8_t interface_id, uint16_t clk_idiv,
+                                       uint32_t* idcode) {
+  if (dev == NULL || idcode == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   const struct hoth_request_jtag_operation request = {
       .clk_idiv = clk_idiv,
       .operation = HOTH_JTAG_OP_READ_IDCODE,
@@ -31,31 +37,38 @@ int libhoth_jtag_read_idcode(struct libhoth_device* dev, uint8_t interface_id,
   struct hoth_response_jtag_read_idcode_operation response;
 
   size_t response_length = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error ret = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), &response, sizeof(response),
       &response_length);
 
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_JTAG_OPERATION error code: %d\n", ret);
-    return -1;
+  if (ret != HOTH_SUCCESS) {
+    fprintf(stderr, "HOTH_JTAG_OPERATION error code: 0x%016llx\n",
+            (unsigned long long)ret);
+    return ret;
   }
 
   if (response_length != sizeof(response)) {
-    fprintf(stderr,
-            "HOTH_JTAG_OPERATION expected exactly %zu reseponse bytes, got %zu",
-            sizeof(response), response_length);
-    return -1;
+    fprintf(
+        stderr,
+        "HOTH_JTAG_OPERATION expected exactly %zu response bytes, got %zu\n",
+        sizeof(response), response_length);
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
   *idcode = response.idcode;
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_jtag_test_bypass(
+libhoth_error libhoth_jtag_test_bypass(
     struct libhoth_device* dev, uint8_t interface_id, uint16_t clk_idiv,
     const uint8_t tdi_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN],
     uint8_t tdo_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN]) {
+  if (dev == NULL || tdi_bytes == NULL || tdo_bytes == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   struct {
     struct hoth_request_jtag_operation operation;
     struct hoth_request_jtag_test_bypass_operation params;
@@ -73,29 +86,37 @@ int libhoth_jtag_test_bypass(
 
   struct hoth_response_jtag_test_bypass_operation response;
   size_t response_len = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error ret = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), &response, sizeof(response),
       &response_len);
 
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_JTAG_OPERATION error code: %d\n", ret);
-    return -1;
+  if (ret != HOTH_SUCCESS) {
+    fprintf(stderr, "HOTH_JTAG_OPERATION error code: 0x%016llx\n",
+            (unsigned long long)ret);
+    return ret;
   }
 
   if (response_len != sizeof(response)) {
-    fprintf(stderr,
-            "HOTH_JTAG_OPERATION expected exactly %zu response bytes, got %zu",
-            sizeof(response), response_len);
-    return -1;
+    fprintf(
+        stderr,
+        "HOTH_JTAG_OPERATION expected exactly %zu response bytes, got %zu\n",
+        sizeof(response), response_len);
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
   memcpy(tdo_bytes, response.tdo_pattern, HOTH_JTAG_TEST_BYPASS_PATTERN_LEN);
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_jtag_program_and_verify_pld(struct libhoth_device* dev,
-                                        uint8_t interface_id, uint32_t offset) {
+libhoth_error libhoth_jtag_program_and_verify_pld(struct libhoth_device* dev,
+                                                  uint8_t interface_id,
+                                                  uint32_t offset) {
+  if (dev == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   struct {
     struct hoth_request_jtag_operation operation;
     struct hoth_request_jtag_program_and_verify_pld_operation params;
@@ -113,28 +134,34 @@ int libhoth_jtag_program_and_verify_pld(struct libhoth_device* dev,
   };
 
   size_t response_length = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error ret = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);
 
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_JTAG_OPERATION error code: %d\n", ret);
-    return -1;
+  if (ret != HOTH_SUCCESS) {
+    fprintf(stderr, "HOTH_JTAG_OPERATION error code: 0x%016llx\n",
+            (unsigned long long)ret);
+    return ret;
   }
 
   if (response_length != 0) {
     fprintf(stderr,
             "HOTH_JTAG_OPERATION expected exactly %u response bytes, got %zu\n",
             0, response_length);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return 0;
+  return HOTH_SUCCESS;
 }
 
-int libhoth_jtag_verify_pld(struct libhoth_device* dev, uint8_t interface_id,
-                            uint32_t offset) {
+libhoth_error libhoth_jtag_verify_pld(struct libhoth_device* dev,
+                                      uint8_t interface_id, uint32_t offset) {
+  if (dev == NULL) {
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_INVALID_PARAMETER);
+  }
   struct {
     struct hoth_request_jtag_operation operation;
     struct hoth_request_jtag_program_and_verify_pld_operation params;
@@ -152,22 +179,24 @@ int libhoth_jtag_verify_pld(struct libhoth_device* dev, uint8_t interface_id,
   };
 
   size_t response_length = 0;
-  int ret = libhoth_hostcmd_exec(
+  libhoth_error ret = libhoth_hostcmd_exec_v2(
       dev, HOTH_CMD_BOARD_SPECIFIC_BASE + HOTH_PRV_CMD_HOTH_JTAG_OPERATION,
       /*version=*/0, &request, sizeof(request), /*resp_buf=*/NULL,
       /*resp_buf_size=*/0, &response_length);
 
-  if (ret != 0) {
-    fprintf(stderr, "HOTH_JTAG_OPERATION error code: %d\n", ret);
-    return -1;
+  if (ret != HOTH_SUCCESS) {
+    fprintf(stderr, "HOTH_JTAG_OPERATION error code: 0x%016llx\n",
+            (unsigned long long)ret);
+    return ret;
   }
 
   if (response_length != 0) {
     fprintf(stderr,
             "HOTH_JTAG_OPERATION expected exactly %u response bytes, got %zu\n",
             0, response_length);
-    return -1;
+    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
+                                 LIBHOTH_ERR_FAIL);
   }
 
-  return 0;
+  return HOTH_SUCCESS;
 }

--- a/protocol/jtag.h
+++ b/protocol/jtag.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 
+#include "protocol/status.h"
 #include "transports/libhoth_device.h"
 
 #ifdef __cplusplus
@@ -83,19 +84,21 @@ struct hoth_response_jtag_test_bypass_operation {
   uint8_t tdo_pattern[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN];
 } __attribute__((packed, aligned(4)));
 
-int libhoth_jtag_read_idcode(struct libhoth_device* dev, uint8_t interface_id,
-                             uint16_t clk_idiv, uint32_t* idcode);
+libhoth_error libhoth_jtag_read_idcode(struct libhoth_device* dev,
+                                       uint8_t interface_id, uint16_t clk_idiv,
+                                       uint32_t* idcode);
 
-int libhoth_jtag_test_bypass(
+libhoth_error libhoth_jtag_test_bypass(
     struct libhoth_device* dev, uint8_t interface_id, uint16_t clk_idiv,
     const uint8_t tdi_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN],
     uint8_t tdo_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN]);
 
-int libhoth_jtag_program_and_verify_pld(struct libhoth_device* dev,
-                                        uint8_t interface_id, uint32_t offset);
+libhoth_error libhoth_jtag_program_and_verify_pld(struct libhoth_device* dev,
+                                                  uint8_t interface_id,
+                                                  uint32_t offset);
 
-int libhoth_jtag_verify_pld(struct libhoth_device* dev, uint8_t interface_id,
-                            uint32_t offset);
+libhoth_error libhoth_jtag_verify_pld(struct libhoth_device* dev,
+                                      uint8_t interface_id, uint32_t offset);
 
 #ifdef __cplusplus
 }

--- a/protocol/jtag_test.cc
+++ b/protocol/jtag_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "jtag.h"
+#include "protocol/jtag.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstdlib>
 
+#include "protocol/status.h"
 #include "protocol/test/libhoth_device_mock.h"
 #include "transports/libhoth_device.h"
 
@@ -53,8 +54,21 @@ TEST_F(LibHothTest, jtag_read_idcode_success) {
   uint16_t clk_idiv = 0;
   EXPECT_EQ(libhoth_jtag_read_idcode(&hoth_dev_, interface_id, clk_idiv,
                                      &received_idcode),
-            LIBHOTH_OK);
+            HOTH_SUCCESS);
   EXPECT_EQ(received_idcode, expected_idcode);
+}
+
+TEST_F(LibHothTest, jtag_read_idcode_null_params) {
+  uint32_t idcode = 0;
+  libhoth_error err = libhoth_jtag_read_idcode(nullptr, 0, 0, &idcode);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
+
+  err = libhoth_jtag_read_idcode(&hoth_dev_, 0, 0, nullptr);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 TEST_F(LibHothTest, jtag_read_idcode_receive_error) {
@@ -69,9 +83,9 @@ TEST_F(LibHothTest, jtag_read_idcode_receive_error) {
   uint32_t received_idcode;
   uint8_t interface_id = 0;
   uint16_t clk_idiv = 0;
-  EXPECT_EQ(libhoth_jtag_read_idcode(&hoth_dev_, interface_id, clk_idiv,
+  EXPECT_NE(libhoth_jtag_read_idcode(&hoth_dev_, interface_id, clk_idiv,
                                      &received_idcode),
-            -1);
+            HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_read_idcode_receive_unexpected_length) {
@@ -92,9 +106,9 @@ TEST_F(LibHothTest, jtag_read_idcode_receive_unexpected_length) {
   uint32_t received_idcode;
   uint8_t interface_id = 0;
   uint16_t clk_idiv = 0;
-  EXPECT_EQ(libhoth_jtag_read_idcode(&hoth_dev_, interface_id, clk_idiv,
+  EXPECT_NE(libhoth_jtag_read_idcode(&hoth_dev_, interface_id, clk_idiv,
                                      &received_idcode),
-            -1);
+            HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_test_bypass_success_with_tdi_tdo_data_match) {
@@ -121,8 +135,28 @@ TEST_F(LibHothTest, jtag_test_bypass_success_with_tdi_tdo_data_match) {
   uint16_t clk_idiv = 0;
   EXPECT_EQ(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
                                      tdi_bytes, tdo_bytes),
-            LIBHOTH_OK);
+            HOTH_SUCCESS);
   EXPECT_THAT(tdo_bytes, testing::ElementsAreArray(tdi_bytes));
+}
+
+TEST_F(LibHothTest, jtag_test_bypass_null_params) {
+  uint8_t tdi[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN] = {};
+  uint8_t tdo[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN] = {};
+
+  libhoth_error err = libhoth_jtag_test_bypass(nullptr, 0, 0, tdi, tdo);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
+
+  err = libhoth_jtag_test_bypass(&hoth_dev_, 0, 0, nullptr, tdo);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
+
+  err = libhoth_jtag_test_bypass(&hoth_dev_, 0, 0, tdi, nullptr);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 TEST_F(LibHothTest, jtag_test_bypass_success_with_tdi_tdo_data_mismatch) {
@@ -149,7 +183,7 @@ TEST_F(LibHothTest, jtag_test_bypass_success_with_tdi_tdo_data_mismatch) {
   uint16_t clk_idiv = 0;
   EXPECT_EQ(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
                                      tdi_bytes, tdo_bytes),
-            LIBHOTH_OK);
+            HOTH_SUCCESS);
   EXPECT_THAT(tdo_bytes, testing::Not(testing::ElementsAreArray(tdi_bytes)));
 }
 
@@ -166,9 +200,9 @@ TEST_F(LibHothTest, jtag_test_bypass_receive_error) {
   uint8_t tdo_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN];
   uint8_t interface_id = 0;
   uint16_t clk_idiv = 0;
-  EXPECT_EQ(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
+  EXPECT_NE(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
                                      tdi_bytes, tdo_bytes),
-            -1);
+            HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_test_bypass_receive_unexpected_length) {
@@ -193,9 +227,9 @@ TEST_F(LibHothTest, jtag_test_bypass_receive_unexpected_length) {
   uint8_t tdo_bytes[HOTH_JTAG_TEST_BYPASS_PATTERN_LEN];
   uint8_t interface_id = 0;
   uint16_t clk_idiv = 0;
-  EXPECT_EQ(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
+  EXPECT_NE(libhoth_jtag_test_bypass(&hoth_dev_, interface_id, clk_idiv,
                                      tdi_bytes, tdo_bytes),
-            -1);
+            HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_program_and_verify_pld_success) {
@@ -205,7 +239,7 @@ TEST_F(LibHothTest, jtag_program_and_verify_pld_success) {
                           _))
       .WillOnce(Return(LIBHOTH_OK));
 
-  uint8_t unused;
+  uint8_t unused = 0;
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&unused, 0), Return(LIBHOTH_OK)));
 
@@ -213,7 +247,14 @@ TEST_F(LibHothTest, jtag_program_and_verify_pld_success) {
   uint8_t interface_id = 0;
   EXPECT_EQ(
       libhoth_jtag_program_and_verify_pld(&hoth_dev_, interface_id, offset),
-      LIBHOTH_OK);
+      HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, jtag_program_and_verify_pld_null_params) {
+  libhoth_error err = libhoth_jtag_program_and_verify_pld(nullptr, 0, 0);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 TEST_F(LibHothTest, jtag_program_and_verify_pld_receive_error) {
@@ -227,9 +268,9 @@ TEST_F(LibHothTest, jtag_program_and_verify_pld_receive_error) {
 
   uint32_t offset = 0;
   uint8_t interface_id = 0;
-  EXPECT_EQ(
+  EXPECT_NE(
       libhoth_jtag_program_and_verify_pld(&hoth_dev_, interface_id, offset),
-      -1);
+      HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_program_and_verify_pld_receive_unexpected_length) {
@@ -246,9 +287,9 @@ TEST_F(LibHothTest, jtag_program_and_verify_pld_receive_unexpected_length) {
 
   uint32_t offset = 0;
   uint8_t interface_id = 0;
-  EXPECT_EQ(
+  EXPECT_NE(
       libhoth_jtag_program_and_verify_pld(&hoth_dev_, interface_id, offset),
-      -1);
+      HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_verify_pld_success) {
@@ -258,14 +299,21 @@ TEST_F(LibHothTest, jtag_verify_pld_success) {
                           _))
       .WillOnce(Return(LIBHOTH_OK));
 
-  uint8_t unused;
+  uint8_t unused = 0;
   EXPECT_CALL(mock_, receive)
       .WillOnce(DoAll(CopyResp(&unused, 0), Return(LIBHOTH_OK)));
 
   uint32_t offset = 0;
   uint8_t interface_id = 0;
   EXPECT_EQ(libhoth_jtag_verify_pld(&hoth_dev_, interface_id, offset),
-            LIBHOTH_OK);
+            HOTH_SUCCESS);
+}
+
+TEST_F(LibHothTest, jtag_verify_pld_null_params) {
+  libhoth_error err = libhoth_jtag_verify_pld(nullptr, 0, 0);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CTX(err), HOTH_CTX_CMD_EXEC);
+  EXPECT_EQ(LIBHOTH_ERR_GET_SPACE(err), HOTH_HOST_SPACE_LIBHOTH);
+  EXPECT_EQ(LIBHOTH_ERR_GET_CODE(err), LIBHOTH_ERR_INVALID_PARAMETER);
 }
 
 TEST_F(LibHothTest, jtag_verify_pld_receive_error) {
@@ -279,7 +327,8 @@ TEST_F(LibHothTest, jtag_verify_pld_receive_error) {
 
   uint32_t offset = 0;
   uint8_t interface_id = 0;
-  EXPECT_EQ(libhoth_jtag_verify_pld(&hoth_dev_, interface_id, offset), -1);
+  EXPECT_NE(libhoth_jtag_verify_pld(&hoth_dev_, interface_id, offset),
+            HOTH_SUCCESS);
 }
 
 TEST_F(LibHothTest, jtag_verify_pld_receive_unexpected_length) {
@@ -296,5 +345,6 @@ TEST_F(LibHothTest, jtag_verify_pld_receive_unexpected_length) {
 
   uint32_t offset = 0;
   uint8_t interface_id = 0;
-  EXPECT_EQ(libhoth_jtag_verify_pld(&hoth_dev_, interface_id, offset), -1);
+  EXPECT_NE(libhoth_jtag_verify_pld(&hoth_dev_, interface_id, offset),
+            HOTH_SUCCESS);
 }


### PR DESCRIPTION
This is the effort to convert the int to the new error format. This case is for the JTAG.