### PR TITLE
[protocol] Convert opentitan_version to use the new compact error format

### DIFF
--- a/examples/htool.c
+++ b/examples/htool.c
@@ -988,9 +988,10 @@ static int command_opentitan_version(const struct htool_invocation* inv) {
   }
 
   struct opentitan_get_version_resp output;
-  const int rv = libhoth_opentitan_version(dev, &output);
-  if (rv) {
-    return rv;
+  const libhoth_error err = libhoth_opentitan_version(dev, &output);
+  if (err != HOTH_SUCCESS) {
+    htool_report_error("opentitan_version", err);
+    return -1;
   }
 
   libhoth_print_ot_version_resp(&output);

--- a/examples/htool_dfu.c
+++ b/examples/htool_dfu.c
@@ -112,19 +112,16 @@ int htool_dfu_update(const struct htool_invocation* inv) {
     retval = 0;
   }
 
-  {
-    int ret = munmap(image, statbuf.st_size);
-    if (ret != 0) {
-      fprintf(stderr, "munmap error: %d\n", ret);
-    }
+  int ret = munmap(image, statbuf.st_size);
+  if (ret != 0) {
+    fprintf(stderr, "munmap error: %d\n", ret);
   }
 
-cleanup: {
-  int ret = close(fd);
+cleanup:
+  ret = close(fd);
   if (ret != 0) {
     fprintf(stderr, "close error: %d\n", ret);
   }
-}
 
   return retval;
 }
@@ -167,7 +164,9 @@ int htool_dfu_check(const struct htool_invocation* inv) {
     goto cleanup;
   }
 
-  if (libhoth_opentitan_version(dev, &resp) != 0) {
+  libhoth_error ot_err = libhoth_opentitan_version(dev, &resp);
+  if (ot_err != HOTH_SUCCESS) {
+    htool_report_error("opentitan_version", ot_err);
     fprintf(stderr, "error: Failed to get current version\n");
     goto cleanup2;
   }

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -485,6 +485,7 @@ cc_test(
     name = "opentitan_version_test",
     srcs = ["opentitan_version_test.cc"],
     deps = [
+        ":libhoth_status",
         ":opentitan_version",
         "//protocol/test:libhoth_device_mock",
         "//transports:libhoth_device",

--- a/protocol/dfu_check.c
+++ b/protocol/dfu_check.c
@@ -65,8 +65,8 @@ void libhoth_print_dfu_error(struct libhoth_device* const dev,
     libhoth_print_ot_version_resp(resp);
   } else {
     struct opentitan_get_version_resp ot_resp;
-    int retval = libhoth_opentitan_version(dev, &ot_resp);
-    if (retval == LIBHOTH_OK) {
+    libhoth_error retval = libhoth_opentitan_version(dev, &ot_resp);
+    if (retval == HOTH_SUCCESS) {
       libhoth_print_ot_version_resp(&ot_resp);
     } else {
       printf("Failed to get OT version information from RoT\n");

--- a/protocol/dfu_hostcmd.c
+++ b/protocol/dfu_hostcmd.c
@@ -165,11 +165,10 @@ libhoth_error libhoth_dfu_install_firmware(struct libhoth_device* dev,
                                  retval);
   }
 
-  retval = libhoth_opentitan_version(dev, &resp);
-  if (retval != 0) {
-    fprintf(stderr, "Failed to get current version (%d)\n", retval);
-    return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
-                                 retval);
+  libhoth_error ot_err = libhoth_opentitan_version(dev, &resp);
+  if (ot_err != HOTH_SUCCESS) {
+    fprintf(stderr, "Failed to get current version\n");
+    return ot_err;
   }
 
   if (desired_app.security_version < resp.bl0_min_sec_ver) {
@@ -191,12 +190,10 @@ libhoth_error libhoth_dfu_install_firmware(struct libhoth_device* dev,
       return err;
     }
 
-    retval = libhoth_opentitan_version(dev, &resp);
-    if (retval != 0) {
-      fprintf(stderr, "Failed to get ot version after dfu update (%d)\n",
-              retval);
-      return LIBHOTH_ERR_CONSTRUCT(HOTH_CTX_CMD_EXEC, HOTH_HOST_SPACE_LIBHOTH,
-                                   retval);
+    ot_err = libhoth_opentitan_version(dev, &resp);
+    if (ot_err != HOTH_SUCCESS) {
+      fprintf(stderr, "Failed to get ot version after dfu update\n");
+      return ot_err;
     }
 
     if (!libhoth_ot_check_update_successful(&resp, &desired_rom_ext,

--- a/protocol/opentitan_version.c
+++ b/protocol/opentitan_version.c
@@ -17,17 +17,15 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "protocol/status.h"
-
-int libhoth_opentitan_version(struct libhoth_device* dev,
-                              struct opentitan_get_version_resp* output) {
+libhoth_error libhoth_opentitan_version(
+    struct libhoth_device* dev, struct opentitan_get_version_resp* output) {
   uint32_t request = 0;
   struct opentitan_get_version_resp response;
-  const int rv = libhoth_hostcmd_exec(dev, HOTH_OPENTITAN_GET_VERSION,
-                                      /*version=*/0, &request, sizeof(request),
-                                      &response, sizeof(response), NULL);
+  const libhoth_error rv = libhoth_hostcmd_exec_v2(
+      dev, HOTH_OPENTITAN_GET_VERSION, /*version=*/0, &request, sizeof(request),
+      &response, sizeof(response), NULL);
 
-  if (rv == 0) {
+  if (rv == HOTH_SUCCESS) {
     *output = response;
   }
 

--- a/protocol/opentitan_version.h
+++ b/protocol/opentitan_version.h
@@ -108,8 +108,8 @@ static_assert(offsetof(struct opentitan_get_version_resp, owner_config) == 296,
               "");
 static_assert(sizeof(struct opentitan_get_version_resp) == 344, "");
 
-int libhoth_opentitan_version(struct libhoth_device* device,
-                              struct opentitan_get_version_resp* response);
+libhoth_error libhoth_opentitan_version(
+    struct libhoth_device* device, struct opentitan_get_version_resp* response);
 
 int libhoth_extract_ot_bundle(const uint8_t* image, size_t image_size,
                               struct opentitan_image_version* rom_ext,

--- a/protocol/opentitan_version_test.cc
+++ b/protocol/opentitan_version_test.cc
@@ -52,7 +52,7 @@ TEST_F(LibHothTest, opentitan_version_test) {
       .WillOnce(DoAll(CopyResp(&mock_response, sizeof(mock_response)),
                       Return(LIBHOTH_OK)));
 
-  EXPECT_EQ(libhoth_opentitan_version(&hoth_dev_, &response), LIBHOTH_OK);
+  EXPECT_EQ(libhoth_opentitan_version(&hoth_dev_, &response), HOTH_SUCCESS);
 
   EXPECT_EQ(response.rom_ext.slots[0].major,
             mock_response.rom_ext.slots[0].major);


### PR DESCRIPTION
Converting the legacy int to the new error format that provides detailed logs for opentitan_version